### PR TITLE
Fix security analysis for scripts on lines

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/repository/SecurityAnalysisResultRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repository/SecurityAnalysisResultRepository.java
@@ -89,6 +89,7 @@ public class SecurityAnalysisResultRepository {
         List<String> generatorIds = new ArrayList<>();
         for (ContingencyElement element : contingency.getElements()) {
             switch (element.getType()) {
+                case LINE:
                 case BRANCH:
                     branchIds.add(element.getId());
                     break;


### PR DESCRIPTION
With newer powsybl versions, lines are sent as lines, not branches and you get the following exception:
security-analysis-server_1     | 2021-05-21 09:46:37.809 ERROR 1 --- [onPool-worker-3] o.g.s.s.s.SecurityAnalysisWorkerService  : Security analysis has failed
security-analysis-server_1     |
security-analysis-server_1     | java.lang.IllegalStateException: Element type yet support: LINE
security-analysis-server_1     | 	at org.gridsuite.securityanalysis.server.repository.SecurityAnalysisResultRepository.toEntity(SecurityAnalysisResultRepository.java:99) ~[classes/:na]
security-analysis-server_1     | 	at org.gridsuite.securityanalysis.server.repository.SecurityAnalysisResultRepository.lambda$insert$5(SecurityAnalysisResultRepository.java:165) ~[classes/:na]

Signed-off-by: Jon Harper <jon.harper87@gmail.com>