### PR TITLE
Remove keyspace name in cql when creating tables 

### DIFF
--- a/src/main/resources/sa.cql
+++ b/src/main/resources/sa.cql
@@ -1,11 +1,11 @@
-CREATE TABLE sa.computationStatus (
+CREATE TABLE computationStatus (
     resultUuid uuid,
     contingencyId text,
     ok boolean,
     PRIMARY KEY (resultUuid, contingencyId)
 );
 
-CREATE TABLE sa.limitViolation (
+CREATE TABLE limitViolation (
     resultUuid uuid,
     limitType text,
     contingencyId text,
@@ -20,7 +20,7 @@ CREATE TABLE sa.limitViolation (
     PRIMARY KEY (resultUuid, limitType, contingencyId, subjectId)
 );
 
-CREATE TABLE sa.contingency (
+CREATE TABLE contingency (
     resultUuid uuid,
     contingencyId text,
     branchIds list<text>,
@@ -28,7 +28,7 @@ CREATE TABLE sa.contingency (
     PRIMARY KEY (resultUuid, contingencyId)
 );
 
-CREATE TABLE sa.globalStatus (
+CREATE TABLE globalStatus (
     resultUuid uuid,
     status text,
     PRIMARY KEY (resultUuid)

--- a/src/test/java/org/gridsuite/securityanalysis/test/EmbeddedCassandraFactoryConfig.java
+++ b/src/test/java/org/gridsuite/securityanalysis/test/EmbeddedCassandraFactoryConfig.java
@@ -36,7 +36,7 @@ public class EmbeddedCassandraFactoryConfig {
     @Bean
     CassandraConnection cassandraConnection(Cassandra cassandra) {
         CassandraConnection cassandraConnection = new DefaultCassandraConnectionFactory().create(cassandra);
-        CqlDataSet.ofClasspaths("create_keyspace.cql", "sa.cql").forEachStatement(cassandraConnection::execute);
+        CqlDataSet.ofClasspaths("create_keyspace.cql").add(CqlDataSet.ofStrings("USE sa;")).add(CqlDataSet.ofClasspaths("sa.cql")).forEachStatement(cassandraConnection::execute);
         return cassandraConnection;
     }
 


### PR DESCRIPTION
otherwise it can't work with other keyspace name (ex: prefixed names)