### PR TITLE
Switch standard consumer concurrency from 1 to 2

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -11,7 +11,7 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}sa.run
           group: saGroup
           consumer:
-            concurrency: 1
+            concurrency: 2
         publishRun-out-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}sa.run
         publishResult-out-0:


### PR DESCRIPTION
This makes it easier to avoid bugs related to the edge case of concurrency: 1

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>