### PR TITLE
Fix Liquibase `diff` when JPA entities not modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ target/
 # IntelliJ
 /.idea
 *.iml
+
+# https://github.com/liquibase/liquibase/issues/2196
+/derby.log

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent-ws</artifactId>
-        <version>17</version>
+        <version>18</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/db/changelog/changesets/changelog_20230801T194601Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230801T194601Z.xml
@@ -3,7 +3,7 @@
     <changeSet author="hedhiliabd" id="1689623201842-1">
         <validCheckSum>8:e772a722c088f772d9dcc4be222f083b</validCheckSum>
         <modifyDataType columnName="element_type"
-                        newDataType="tinyint"
+                        newDataType="smallint"
                         tableName="contingency_entity_contingency_elements"/>
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20231017T131658Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20231017T131658Z.xml
@@ -1,0 +1,27 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:pro="http://www.liquibase.org/xml/ns/pro"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="chuinetri (generated)" id="1697548639163-1">
+        <comment>Missing update from #61</comment>
+        <modifyDataType columnName="status" newDataType="varchar(255)" tableName="computation_status"/>
+        <dropColumn columnName="ok" tableName="computation_status"/>
+    </changeSet>
+
+    <changeSet author="chuinetri (base generated)" id="1697548639163-2">
+        <comment>We reconstruct primary/foreign keys constraints</comment>
+        <dropForeignKeyConstraint baseTableName="contingency_entity_contingency_elements" constraintName="FKPNMUIJ3QKI9U4KF7OMME39UGN"/>
+        <dropPrimaryKey tableName="contingency"/>
+    </changeSet>
+    <changeSet author="chuinetri (base generated)" id="1697548639163-3">
+        <comment>Next part of 1697548639163-2</comment>
+        <addPrimaryKey columnNames="contingency_id, result_uuid" constraintName="contingencyPK" tableName="contingency"/>
+        <createIndex indexName="IX_contingencyPK" tableName="contingency" unique="true">
+            <column name="contingency_id"/>
+            <column name="result_uuid"/>
+        </createIndex>
+        <addForeignKeyConstraint baseColumnNames="contingency_entity_contingency_id,contingency_entity_result_uuid" baseTableName="contingency_entity_contingency_elements" constraintName="FKpnmuij3qki9u4kf7omme39ugn" deferrable="false" initiallyDeferred="false" referencedColumnNames="contingency_id,result_uuid" referencedTableName="contingency" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,4 @@
 databaseChangeLog:
-
   - include:
       file: changesets/changelog_20220204T114931Z.xml
       relativeToChangelogFile: true
@@ -11,4 +10,7 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changesets/changelog_20230801T194601Z.xml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/changelog_20231017T131658Z.xml
       relativeToChangelogFile: true

--- a/src/test/resources/application-default.yml
+++ b/src/test/resources/application-default.yml
@@ -16,7 +16,7 @@ logging:
 powsybl-ws:
   database:
     vendor: h2:mem
-    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    query: ;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=PostgreSQL;DEFAULT_NULL_ORDERING=HIGH
     hostPort: ":"
 
 


### PR DESCRIPTION
Liquibase `diff` generate changes when using `main` branch without modifying JPA entities.  
* The diff come from recent migrations updating some rules in Liquibase.
* Also add missing compatibility mode in H2 configuration
* ⚠️ need release v18 of powsybl/powsybl-parent/pull/54