### PR TITLE
Improve delete result speed by using SQL queries

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyLimitViolationRepository.java
@@ -22,6 +22,6 @@ import java.util.UUID;
 @Repository
 public interface ContingencyLimitViolationRepository extends JpaRepository<ContingencyLimitViolationEntity, UUID> {
     @Modifying
-    @Query(value = "DELETE FROM ContingencyLimitViolationEntity WHERE contingency.uuid IN ?1")
+    @Query(value = "DELETE FROM contingency_limit_violation WHERE contingency_uuid IN ?1", nativeQuery = true)
     void deleteAllByContingencyUuidIn(Set<UUID> uuids);
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyLimitViolationRepository.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package org.gridsuite.securityanalysis.server.repositories;
+
+import org.gridsuite.securityanalysis.server.entities.ContingencyLimitViolationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * @author Florent MILLOT <florent.millot@rte-france.com>
+ */
+@Repository
+public interface ContingencyLimitViolationRepository extends JpaRepository<ContingencyLimitViolationEntity, UUID> {
+    @Modifying
+    @Query(value = "DELETE FROM ContingencyLimitViolationEntity WHERE contingency.uuid IN ?1")
+    void deleteAllByContingencyUuidIn(Set<UUID> uuids);
+}

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyRepository.java
@@ -11,12 +11,11 @@ import org.gridsuite.securityanalysis.server.dto.ResourceFilterDTO;
 import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.util.SecurityAnalysisException;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -32,6 +31,13 @@ public interface ContingencyRepository extends CommonLimitViolationRepository<Co
     List<ContingencyEntity> findAllWithContingencyElementsByUuidIn(List<UUID> uuids);
 
     List<ContingencyEntity> findAllByUuidIn(List<UUID> uuids);
+
+    @Query(value = "SELECT uuid FROM ContingencyEntity WHERE result.id = ?1")
+    Set<UUID> findAllUuidsByResultId(UUID resultId);
+
+    @Modifying
+    @Query(value = "DELETE FROM ContingencyEntity WHERE result.id = ?1")
+    void deleteAllByResultId(UUID resultId);
 
     @Override
     default String columnToDotSeparatedField(ResourceFilterDTO.Column column) {

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/ContingencyRepository.java
@@ -36,8 +36,12 @@ public interface ContingencyRepository extends CommonLimitViolationRepository<Co
     Set<UUID> findAllUuidsByResultId(UUID resultId);
 
     @Modifying
-    @Query(value = "DELETE FROM ContingencyEntity WHERE result.id = ?1")
+    @Query(value = "DELETE FROM contingency WHERE result_id = ?1", nativeQuery = true)
     void deleteAllByResultId(UUID resultId);
+
+    @Modifying
+    @Query(value = "DELETE FROM contingency_entity_contingency_elements WHERE contingency_entity_uuid IN ?1", nativeQuery = true)
+    void deleteAllContingencyElementsByContingencyUuidIn(Set<UUID> uuids);
 
     @Override
     default String columnToDotSeparatedField(ResourceFilterDTO.Column column) {

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/PreContingencyLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/PreContingencyLimitViolationRepository.java
@@ -85,6 +85,6 @@ public interface PreContingencyLimitViolationRepository extends JpaRepository<Pr
     }
 
     @Modifying
-    @Query(value = "DELETE FROM PreContingencyLimitViolationEntity WHERE result.id = ?1")
+    @Query(value = "DELETE FROM pre_contingency_limit_violation WHERE result_id = ?1", nativeQuery = true)
     void deleteAllByResultId(UUID resultId);
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/PreContingencyLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/PreContingencyLimitViolationRepository.java
@@ -13,9 +13,7 @@ import org.gridsuite.securityanalysis.server.dto.ResourceFilterDTO;
 import org.gridsuite.securityanalysis.server.entities.PreContingencyLimitViolationEntity;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,4 +83,8 @@ public interface PreContingencyLimitViolationRepository extends JpaRepository<Pr
     default boolean isParentFilter(String filter) {
         return filter.equals("subjectId");
     }
+
+    @Modifying
+    @Query(value = "DELETE FROM PreContingencyLimitViolationEntity WHERE result.id = ?1")
+    void deleteAllByResultId(UUID resultId);
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/SubjectLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/SubjectLimitViolationRepository.java
@@ -10,9 +10,7 @@ import org.gridsuite.securityanalysis.server.dto.ResourceFilterDTO;
 import org.gridsuite.securityanalysis.server.entities.SubjectLimitViolationEntity;
 import org.gridsuite.securityanalysis.server.util.SecurityAnalysisException;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.*;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -55,4 +53,8 @@ public interface SubjectLimitViolationRepository extends CommonLimitViolationRep
     default String getIdFieldName() {
         return "id";
     }
+
+    @Modifying
+    @Query(value = "DELETE FROM SubjectLimitViolationEntity WHERE result.id = ?1")
+    void deleteAllByResultId(UUID resultId);
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/SubjectLimitViolationRepository.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/SubjectLimitViolationRepository.java
@@ -55,6 +55,6 @@ public interface SubjectLimitViolationRepository extends CommonLimitViolationRep
     }
 
     @Modifying
-    @Query(value = "DELETE FROM SubjectLimitViolationEntity WHERE result.id = ?1")
+    @Query(value = "DELETE FROM subject_limit_violation WHERE result_id = ?1", nativeQuery = true)
     void deleteAllByResultId(UUID resultId);
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -15,11 +15,10 @@ import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.entities.PreContingencyLimitViolationEntity;
 import org.gridsuite.securityanalysis.server.entities.SecurityAnalysisResultEntity;
 import org.gridsuite.securityanalysis.server.entities.SubjectLimitViolationEntity;
-import org.gridsuite.securityanalysis.server.repositories.ContingencyRepository;
-import org.gridsuite.securityanalysis.server.repositories.PreContingencyLimitViolationRepository;
-import org.gridsuite.securityanalysis.server.repositories.SecurityAnalysisResultRepository;
-import org.gridsuite.securityanalysis.server.repositories.SubjectLimitViolationRepository;
+import org.gridsuite.securityanalysis.server.repositories.*;
 import org.gridsuite.securityanalysis.server.util.SecurityAnalysisException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Page;
@@ -31,16 +30,20 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
 @Service
 public class SecurityAnalysisResultService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SecurityAnalysisResultService.class);
     private final SecurityAnalysisResultRepository securityAnalysisResultRepository;
     private final ContingencyRepository contingencyRepository;
     private final PreContingencyLimitViolationRepository preContingencyLimitViolationRepository;
     private final SubjectLimitViolationRepository subjectLimitViolationRepository;
+    private final ContingencyLimitViolationRepository contingencyLimitViolationRepository;
     private final ObjectMapper objectMapper;
     private SecurityAnalysisResultService self;
 
@@ -49,12 +52,14 @@ public class SecurityAnalysisResultService {
                                          ContingencyRepository contingencyRepository,
                                          PreContingencyLimitViolationRepository preContingencyLimitViolationRepository,
                                          SubjectLimitViolationRepository subjectLimitViolationRepository,
+                                         ContingencyLimitViolationRepository contingencyLimitViolationRepository,
                                          @Lazy SecurityAnalysisResultService self,
                                          ObjectMapper objectMapper) {
         this.securityAnalysisResultRepository = securityAnalysisResultRepository;
         this.contingencyRepository = contingencyRepository;
         this.preContingencyLimitViolationRepository = preContingencyLimitViolationRepository;
         this.subjectLimitViolationRepository = subjectLimitViolationRepository;
+        this.contingencyLimitViolationRepository = contingencyLimitViolationRepository;
         this.objectMapper = objectMapper;
         this.self = self;
     }
@@ -167,8 +172,23 @@ public class SecurityAnalysisResultService {
 
     @Transactional
     public void delete(UUID resultUuid) {
+        AtomicReference<Long> startTime = new AtomicReference<>();
+        startTime.set(System.nanoTime());
         Objects.requireNonNull(resultUuid);
-        securityAnalysisResultRepository.deleteById(resultUuid);
+        deleteWithSQLQueries(resultUuid);
+        LOGGER.info("Security analysis result '{}' has been deleted in {}ms", resultUuid, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime.get()));
+    }
+
+    // We manually delete the results here using SQL queries to improve performances.
+    // source : https://www.baeldung.com/spring-data-jpa-deleteby
+    // "The @Query method creates a single SQL query against the database. By comparison, the deleteBy methods execute a read query, then delete each of the items one by one."
+    private void deleteWithSQLQueries(UUID resultId) {
+        Set<UUID> contingencyUuids = contingencyRepository.findAllUuidsByResultId(resultId);
+        contingencyLimitViolationRepository.deleteAllByContingencyUuidIn(contingencyUuids);
+        contingencyRepository.deleteAllByResultId(resultId);
+        preContingencyLimitViolationRepository.deleteAllByResultId(resultId);
+        subjectLimitViolationRepository.deleteAllByResultId(resultId);
+        securityAnalysisResultRepository.deleteById(resultId);
     }
 
     @Transactional

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -175,14 +175,14 @@ public class SecurityAnalysisResultService {
         AtomicReference<Long> startTime = new AtomicReference<>();
         startTime.set(System.nanoTime());
         Objects.requireNonNull(resultUuid);
-        deleteWithSQLQueries(resultUuid);
+        deleteSecurityAnalysisResult(resultUuid);
         LOGGER.info("Security analysis result '{}' has been deleted in {}ms", resultUuid, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime.get()));
     }
 
     // We manually delete the results here using SQL queries to improve performances.
     // source : https://www.baeldung.com/spring-data-jpa-deleteby
     // "The @Query method creates a single SQL query against the database. By comparison, the deleteBy methods execute a read query, then delete each of the items one by one."
-    private void deleteWithSQLQueries(UUID resultId) {
+    private void deleteSecurityAnalysisResult(UUID resultId) {
         Set<UUID> contingencyUuids = contingencyRepository.findAllUuidsByResultId(resultId);
         contingencyLimitViolationRepository.deleteAllByContingencyUuidIn(contingencyUuids);
         contingencyRepository.deleteAllByResultId(resultId);

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -185,6 +185,7 @@ public class SecurityAnalysisResultService {
     private void deleteSecurityAnalysisResult(UUID resultId) {
         Set<UUID> contingencyUuids = contingencyRepository.findAllUuidsByResultId(resultId);
         contingencyLimitViolationRepository.deleteAllByContingencyUuidIn(contingencyUuids);
+        contingencyRepository.deleteAllContingencyElementsByContingencyUuidIn(contingencyUuids);
         contingencyRepository.deleteAllByResultId(resultId);
         preContingencyLimitViolationRepository.deleteAllByResultId(resultId);
         subjectLimitViolationRepository.deleteAllByResultId(resultId);

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -182,6 +182,7 @@ public class SecurityAnalysisResultService {
     // We manually delete the results here using SQL queries to improve performances.
     // source : https://www.baeldung.com/spring-data-jpa-deleteby
     // "The @Query method creates a single SQL query against the database. By comparison, the deleteBy methods execute a read query, then delete each of the items one by one."
+    // Note : we use native SQL instead of JPQL because there is no cascade even on embeddable collections so we keep total control on launched queries.
     private void deleteSecurityAnalysisResult(UUID resultId) {
         Set<UUID> contingencyUuids = contingencyRepository.findAllUuidsByResultId(resultId);
         contingencyLimitViolationRepository.deleteAllByContingencyUuidIn(contingencyUuids);

--- a/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
@@ -85,7 +85,7 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
     static final LimitViolation LIMIT_VIOLATION_5 = new LimitViolation("vl5", LimitViolationType.LOW_VOLTAGE, "vl5_name", 0, 350, 3, 416, Branch.Side.TWO);
     static final List<LimitViolation> RESULT_LIMIT_VIOLATIONS = List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2);
     static final List<LimitViolation> FAILED_LIMIT_VIOLATIONS = List.of(LIMIT_VIOLATION_3, LIMIT_VIOLATION_4);
-    static final SecurityAnalysisResult RESULT = new SecurityAnalysisResult(new LimitViolationsResult(List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_3)), LoadFlowResult.ComponentResult.Status.CONVERGED,
+    public static final SecurityAnalysisResult RESULT = new SecurityAnalysisResult(new LimitViolationsResult(List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_3)), LoadFlowResult.ComponentResult.Status.CONVERGED,
             Stream.concat(
                             CONTINGENCIES.stream().map(contingency -> new PostContingencyResult(contingency, PostContingencyComputationStatus.CONVERGED, RESULT_LIMIT_VIOLATIONS)),
                             FAILED_CONTINGENCIES.stream().map(contingency -> new PostContingencyResult(contingency, PostContingencyComputationStatus.FAILED, FAILED_LIMIT_VIOLATIONS)))

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
@@ -1,0 +1,34 @@
+package org.gridsuite.securityanalysis.server.service;
+
+import com.vladmihalcea.sql.SQLStatementCountValidator;
+import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.UUID;
+
+import static com.vladmihalcea.sql.SQLStatementCountValidator.*;
+import static org.gridsuite.securityanalysis.server.SecurityAnalysisProviderMock.RESULT;
+
+/**
+ * @author Florent MILLOT <florent.millot@rte-france.com>
+ */
+@SpringBootTest
+class SecurityAnalysisResultServiceTest {
+
+    @Autowired
+    SecurityAnalysisResultService securityAnalysisResultService;
+
+    @Test
+    void deleteResultPerfTest() {
+        UUID resultUuid = UUID.randomUUID();
+        securityAnalysisResultService.insert(resultUuid, RESULT, SecurityAnalysisStatus.CONVERGED);
+        SQLStatementCountValidator.reset();
+
+        securityAnalysisResultService.delete(resultUuid);
+
+        // 5 manual deletes + the list of ContingencyElementEmbeddable inside ContingencyEntity
+        assertDeleteCount(6);
+    }
+}

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
@@ -15,8 +15,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.UUID;
 
-import static com.vladmihalcea.sql.SQLStatementCountValidator.assertDeleteCount;
 import static org.gridsuite.securityanalysis.server.SecurityAnalysisProviderMock.RESULT;
+import static org.gridsuite.securityanalysis.server.util.DatabaseQueryUtils.assertRequestsCount;
 
 /**
  * @author Florent MILLOT <florent.millot@rte-france.com>
@@ -35,7 +35,8 @@ class SecurityAnalysisResultServiceTest {
 
         securityAnalysisResultService.delete(resultUuid);
 
-        // 5 manual deletes + the list of ContingencyElementEmbeddable inside ContingencyEntity
-        assertDeleteCount(6);
+        // 6 manual delete
+        // 1 manual select to get the contingencyUuids, and 4 select at the end for the last delete when applying the cascade
+        assertRequestsCount(5, 0, 0, 6);
     }
 }

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.UUID;
 
-import static com.vladmihalcea.sql.SQLStatementCountValidator.*;
+import static com.vladmihalcea.sql.SQLStatementCountValidator.assertDeleteCount;
 import static org.gridsuite.securityanalysis.server.SecurityAnalysisProviderMock.RESULT;
 
 /**

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultServiceTest.java
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
 package org.gridsuite.securityanalysis.server.service;
 
 import com.vladmihalcea.sql.SQLStatementCountValidator;

--- a/src/test/java/org/gridsuite/securityanalysis/server/util/DatabaseQueryUtils.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/util/DatabaseQueryUtils.java
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package org.gridsuite.securityanalysis.server.util;
 
 import static com.vladmihalcea.sql.SQLStatementCountValidator.*;

--- a/src/test/java/org/gridsuite/securityanalysis/server/util/DatabaseQueryUtils.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/util/DatabaseQueryUtils.java
@@ -1,0 +1,18 @@
+package org.gridsuite.securityanalysis.server.util;
+
+import static com.vladmihalcea.sql.SQLStatementCountValidator.*;
+import static com.vladmihalcea.sql.SQLStatementCountValidator.assertDeleteCount;
+
+public final class DatabaseQueryUtils {
+
+    private DatabaseQueryUtils() {
+        throw new IllegalStateException("Not implemented exception");
+    }
+
+    public static void assertRequestsCount(long select, long insert, long update, long delete) {
+        assertSelectCount(select);
+        assertInsertCount(insert);
+        assertUpdateCount(update);
+        assertDeleteCount(delete);
+    }
+}


### PR DESCRIPTION
Refactor ContingencyRepository, PreContingencyLimitViolationRepository, and SubjectLimitViolationRepository to use the Modifying and Query annotations for deleting records by resultId. Additionally, create the ContingencyLimitViolationRepository interface for deleting ContingencyLimitViolationEntity records by contingencyUuid.