### PR TITLE
handle userId and shorten error messages

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
+import static org.gridsuite.securityanalysis.server.service.NotificationService.HEADER_USER_ID;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.TEXT_PLAIN_VALUE;
 
@@ -71,9 +72,10 @@ public class SecurityAnalysisController {
                                                             @Parameter(description = "reportUuid") @RequestParam(name = "reportUuid", required = false) UUID reportUuid,
                                                             @Parameter(description = "reporterId") @RequestParam(name = "reporterId", required = false) String reporterId,
                                                             @Parameter(description = "The type name for the report") @RequestParam(name = "reportType", required = false, defaultValue = "SecurityAnalysis") String reportType,
-                                                            @RequestBody(required = false) SecurityAnalysisParametersInfos parameters) {
+                                                            @RequestBody(required = false) SecurityAnalysisParametersInfos parameters,
+                                                            @RequestHeader(HEADER_USER_ID) String userId) {
         String providerToUse = provider != null ? provider : securityAnalysisService.getDefaultProvider();
-        SecurityAnalysisResult result = workerService.run(new SecurityAnalysisRunContext(networkUuid, variantId, contigencyListNames, null, providerToUse, parameters, reportUuid, reporterId, reportType));
+        SecurityAnalysisResult result = workerService.run(new SecurityAnalysisRunContext(networkUuid, variantId, contigencyListNames, null, providerToUse, parameters, reportUuid, reporterId, reportType, userId));
 
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
     }
@@ -92,9 +94,10 @@ public class SecurityAnalysisController {
                                                  @Parameter(description = "reportUuid") @RequestParam(name = "reportUuid", required = false) UUID reportUuid,
                                                  @Parameter(description = "reporterId") @RequestParam(name = "reporterId", required = false) String reporterId,
                                                  @Parameter(description = "The type name for the report") @RequestParam(name = "reportType", required = false, defaultValue = "SecurityAnalysis") String reportType,
-                                                 @RequestBody(required = false) SecurityAnalysisParametersInfos parameters) {
+                                                 @RequestBody(required = false) SecurityAnalysisParametersInfos parameters,
+                                                 @RequestHeader(HEADER_USER_ID) String userId) {
         String providerToUse = provider != null ? provider : securityAnalysisService.getDefaultProvider();
-        UUID resultUuid = securityAnalysisService.runAndSaveResult(new SecurityAnalysisRunContext(networkUuid, variantId, contigencyListNames, receiver, providerToUse, parameters, reportUuid, reporterId, reportType));
+        UUID resultUuid = securityAnalysisService.runAndSaveResult(new SecurityAnalysisRunContext(networkUuid, variantId, contigencyListNames, receiver, providerToUse, parameters, reportUuid, reporterId, reportType, userId));
         return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(resultUuid);
     }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/NotificationService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/NotificationService.java
@@ -91,12 +91,8 @@ public class NotificationService {
             return msg;
         }
 
-        String shortMsg = msg;
-        if (shortMsg.length() > MSG_MAX_LENGTH) {
-            shortMsg = msg.substring(0, MSG_MAX_LENGTH / 2) +
-                    " ... " +
-                    msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1);
-        }
-        return shortMsg;
+        return msg.length() > MSG_MAX_LENGTH ?
+                msg.substring(0, MSG_MAX_LENGTH / 2) + " ... " + msg.substring(msg.length() - MSG_MAX_LENGTH / 2, msg.length() - 1)
+                : msg;
     }
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultContext.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultContext.java
@@ -70,6 +70,7 @@ public class SecurityAnalysisResultContext {
         List<String> contingencyListNames = getHeaderList(headers, CONTINGENCY_LIST_NAMES_HEADER);
         String receiver = (String) headers.get(RECEIVER_HEADER);
         String provider = (String) headers.get(PROVIDER_HEADER);
+        String userId = (String) headers.get(HEADER_USER_ID);
         SecurityAnalysisParameters parameters;
         try {
             parameters = objectMapper.readValue(message.getPayload(), SecurityAnalysisParameters.class);
@@ -79,7 +80,7 @@ public class SecurityAnalysisResultContext {
         UUID reportUuid = headers.containsKey(REPORT_UUID_HEADER) ? UUID.fromString((String) headers.get(REPORT_UUID_HEADER)) : null;
         String reporterId = headers.containsKey(REPORTER_ID_HEADER) ? (String) headers.get(REPORTER_ID_HEADER) : null;
         String reportType = headers.containsKey(REPORT_TYPE_HEADER) ? (String) headers.get(REPORT_TYPE_HEADER) : null;
-        SecurityAnalysisRunContext runContext = new SecurityAnalysisRunContext(networkUuid, variantId, contingencyListNames, receiver, provider, parameters, reportUuid, reporterId, reportType);
+        SecurityAnalysisRunContext runContext = new SecurityAnalysisRunContext(networkUuid, variantId, contingencyListNames, receiver, provider, parameters, reportUuid, reporterId, reportType, userId);
         return new SecurityAnalysisResultContext(resultUuid, runContext);
     }
 
@@ -96,6 +97,7 @@ public class SecurityAnalysisResultContext {
                 .setHeader(VARIANT_ID_HEADER, runContext.getVariantId())
                 .setHeader(CONTINGENCY_LIST_NAMES_HEADER, String.join(",", runContext.getContingencyListNames()))
                 .setHeader(RECEIVER_HEADER, runContext.getReceiver())
+                .setHeader(HEADER_USER_ID, runContext.getUserId())
                 .setHeader(PROVIDER_HEADER, runContext.getProvider())
                 .setHeader(REPORT_UUID_HEADER, runContext.getReportUuid())
                 .setHeader(REPORTER_ID_HEADER, runContext.getReporterId())

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisRunContext.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisRunContext.java
@@ -11,6 +11,7 @@ import com.powsybl.commons.extensions.Extension;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.loadflow.LoadFlowProvider;
 import com.powsybl.security.SecurityAnalysisParameters;
+import lombok.Getter;
 import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisParametersInfos;
 
 import java.util.List;
@@ -20,6 +21,7 @@ import java.util.UUID;
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
  */
+@Getter
 public class SecurityAnalysisRunContext {
 
     private final UUID networkUuid;
@@ -38,15 +40,19 @@ public class SecurityAnalysisRunContext {
 
     private final String reporterId;
 
+    private final String userId;
+
     private final String reportType;
 
     public SecurityAnalysisRunContext(UUID networkUuid, String variantId, List<String> contingencyListNames,
-                                      String receiver, String provider, SecurityAnalysisParametersInfos parameters, UUID reportUuid, String reporterId, String reportType) {
-        this(networkUuid, variantId, contingencyListNames, receiver, provider, buildParameters(parameters, provider), reportUuid, reporterId, reportType);
+                                      String receiver, String provider, SecurityAnalysisParametersInfos parameters,
+                                      UUID reportUuid, String reporterId, String reportType, String userId) {
+        this(networkUuid, variantId, contingencyListNames, receiver, provider, buildParameters(parameters, provider), reportUuid, reporterId, reportType, userId);
     }
 
     public SecurityAnalysisRunContext(UUID networkUuid, String variantId, List<String> contingencyListNames,
-                                      String receiver, String provider, SecurityAnalysisParameters parameters, UUID reportUuid, String reporterId, String reportType) {
+                                      String receiver, String provider, SecurityAnalysisParameters parameters,
+                                      UUID reportUuid, String reporterId, String reportType, String userId) {
         this.networkUuid = Objects.requireNonNull(networkUuid);
         this.variantId = variantId;
         this.contingencyListNames = Objects.requireNonNull(contingencyListNames);
@@ -55,6 +61,7 @@ public class SecurityAnalysisRunContext {
         this.parameters = Objects.requireNonNull(parameters);
         this.reportUuid = reportUuid;
         this.reporterId = reporterId;
+        this.userId = userId;
         this.reportType = reportType;
     }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
@@ -182,14 +182,14 @@ public class SecurityAnalysisWorkerService {
     private SecurityAnalysisResult run(SecurityAnalysisRunContext context, UUID resultUuid) throws ExecutionException, InterruptedException {
         Objects.requireNonNull(context);
 
-        LOGGER.info("Run security analysis on contingency lists: {}", context.getContingencyListNames().stream().map(LogUtils::sanitizeParam).collect(Collectors.toList()));
+        LOGGER.info("Run security analysis on contingency lists: {}", context.getContingencyListNames().stream().map(LogUtils::sanitizeParam).toList());
 
         Network network = getNetwork(context.getNetworkUuid());
 
         List<Contingency> contingencies = context.getContingencyListNames().stream()
             .map(contingencyListName -> actionsService.getContingencyList(contingencyListName, context.getNetworkUuid(), context.getVariantId()))
             .flatMap(List::stream)
-            .collect(Collectors.toList());
+            .toList();
 
         SecurityAnalysis.Runner securityAnalysisRunner = securityAnalysisFactorySupplier.apply(context.getProvider());
 
@@ -252,7 +252,8 @@ public class SecurityAnalysisWorkerService {
                     LOGGER.error(FAIL_MESSAGE, e);
                     notificationService.emitFailAnalysisMessage(resultContext.getResultUuid().toString(),
                         resultContext.getRunContext().getReceiver(),
-                        e.getMessage());
+                        e.getMessage(),
+                        resultContext.getRunContext().getUserId());
                     securityAnalysisResultService.delete(resultContext.getResultUuid());
                 }
             } finally {

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
@@ -50,7 +50,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.gridsuite.securityanalysis.server.service.NotificationService.CANCEL_MESSAGE;
 import static org.gridsuite.securityanalysis.server.service.NotificationService.FAIL_MESSAGE;

--- a/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisControllerTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisControllerTest.java
@@ -59,6 +59,7 @@ import static com.powsybl.network.store.model.NetworkStoreApi.VERSION;
 import static org.gridsuite.securityanalysis.server.SecurityAnalysisProviderMock.*;
 import static org.gridsuite.securityanalysis.server.service.NotificationService.CANCEL_MESSAGE;
 import static org.gridsuite.securityanalysis.server.service.NotificationService.FAIL_MESSAGE;
+import static org.gridsuite.securityanalysis.server.service.NotificationService.HEADER_USER_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -189,6 +190,7 @@ public class SecurityAnalysisControllerTest {
     public void simpleRunRequest(SecurityAnalysisParametersInfos lfParams) {
         MvcResult mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME_VARIANT + "&variantId=" + VARIANT_3_ID)
                 .contentType(MediaType.APPLICATION_JSON)
+                .header(HEADER_USER_ID, "testUserId")
                 .content(mapper.writeValueAsString(lfParams)))
                 .andExpectAll(
                     status().isOk(),
@@ -221,7 +223,8 @@ public class SecurityAnalysisControllerTest {
         String resultAsString;
 
         // run with specific variant
-        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME_VARIANT + "&variantId=" + VARIANT_3_ID + "&provider=OpenLoadFlow"))
+        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME_VARIANT + "&variantId=" + VARIANT_3_ID + "&provider=OpenLoadFlow")
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON)
@@ -232,7 +235,8 @@ public class SecurityAnalysisControllerTest {
         assertThat(RESULT_VARIANT, new MatcherJson<>(mapper, securityAnalysisResult));
 
         // run with implicit initial variant
-        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME))
+        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME)
+           .header(HEADER_USER_ID, "testUserId"))
            .andExpectAll(
                status().isOk(),
                content().contentType(MediaType.APPLICATION_JSON)
@@ -249,7 +253,8 @@ public class SecurityAnalysisControllerTest {
         String resultAsString;
 
         mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME
-            + "&receiver=me&variantId=" + VARIANT_2_ID + "&provider=OpenLoadFlow"))
+            + "&receiver=me&variantId=" + VARIANT_2_ID + "&provider=OpenLoadFlow")
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON)
@@ -330,7 +335,8 @@ public class SecurityAnalysisControllerTest {
         String resultAsString;
 
         mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME +
-            "&contingencyListName=" + CONTINGENCY_LIST2_NAME + "&variantId=" + VARIANT_1_ID))
+            "&contingencyListName=" + CONTINGENCY_LIST2_NAME + "&variantId=" + VARIANT_1_ID)
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON)
@@ -345,7 +351,8 @@ public class SecurityAnalysisControllerTest {
         MvcResult mvcResult;
         String resultAsString;
 
-        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME))
+        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME)
+            .header(HEADER_USER_ID, "testUserId"))
             .andExpectAll(
                 status().isOk(),
                 content().contentType(MediaType.APPLICATION_JSON)
@@ -389,7 +396,8 @@ public class SecurityAnalysisControllerTest {
 
         // running computation to create result
         mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME
-            + "&receiver=me&variantId=" + VARIANT_2_ID + "&provider=OpenLoadFlow"))
+            + "&receiver=me&variantId=" + VARIANT_2_ID + "&provider=OpenLoadFlow")
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON)
@@ -433,7 +441,8 @@ public class SecurityAnalysisControllerTest {
                 MvcResult mvcResult;
                 String resultAsString;
                 mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_STOP_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME
-                        + "&receiver=me&variantId=" + VARIANT_TO_STOP_ID))
+                        + "&receiver=me&variantId=" + VARIANT_TO_STOP_ID)
+                    .header(HEADER_USER_ID, "testUserId"))
                     .andExpectAll(
                         status().isOk(),
                         content().contentType(MediaType.APPLICATION_JSON)
@@ -469,7 +478,8 @@ public class SecurityAnalysisControllerTest {
             .willThrow(new RuntimeException(ERROR_MESSAGE));
 
         mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run-and-save?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_ERROR_NAME
-            + "&receiver=me&variantId=" + VARIANT_1_ID))
+            + "&receiver=me&variantId=" + VARIANT_1_ID)
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON)
@@ -494,7 +504,8 @@ public class SecurityAnalysisControllerTest {
         MvcResult mvcResult;
         String resultAsString;
 
-        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME + "&provider=testProvider" + "&reportUuid=" + REPORT_UUID + "&reporterId=" + UUID.randomUUID()).contentType(MediaType.APPLICATION_JSON))
+        mvcResult = mockMvc.perform(post("/" + VERSION + "/networks/" + NETWORK_UUID + "/run?reportType=SecurityAnalysis&contingencyListName=" + CONTINGENCY_LIST_NAME + "&provider=testProvider" + "&reportUuid=" + REPORT_UUID + "&reporterId=" + UUID.randomUUID()).contentType(MediaType.APPLICATION_JSON)
+                .header(HEADER_USER_ID, "testUserId"))
                 .andExpectAll(
                     status().isOk(),
                     content().contentType(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
1 Bug fix : The full error message is still logged but only a shortened version is sent through rabbitmq (prevents it from crashing).

2. userId is added to the run context and transmitted in the messages (because it is needed in order to display the error messages on the front side)