### PR TITLE
Add sort on childrens for NmK results

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -49,15 +49,33 @@ public class SecurityAnalysisResultService {
     private final ObjectMapper objectMapper;
     private SecurityAnalysisResultService self;
 
-    private static final String DEFAULT_CONTINGENCY_SORT_COLUMN = "uuid";
-
-    private static final String DEFAULT_SUBJECT_LIMIT_VIOLATION_SORT_COLUMN = "id";
-
     private static final Sort.Direction DEFAULT_SORT_DIRECTION = Sort.Direction.ASC;
 
-    private static final List<String> ALLOWED_NMK_CONTINGENCIES_RESULT_SORT_PROPERTIES = List.of(ContingencyEntity.Fields.contingencyId, ContingencyEntity.Fields.status);
+    private static final List<String> ALLOWED_NMK_CONTINGENCIES_RESULT_SORT_PROPERTIES = List.of(
+        ContingencyEntity.Fields.contingencyId,
+        ContingencyEntity.Fields.status,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitType,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitName,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limit,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.value,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.loading,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.acceptableDuration,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side,
+        ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.subjectLimitViolation + SpecificationUtils.FIELD_SEPARATOR + SubjectLimitViolationEntity.Fields.subjectId
+    );
 
-    private static final List<String> ALLOWED_NMK_SUBJECT_LIMIT_VIOLATIONS_RESULT_SORT_PROPERTIES = List.of(SubjectLimitViolationEntity.Fields.subjectId);
+    private static final List<String> ALLOWED_NMK_SUBJECT_LIMIT_VIOLATIONS_RESULT_SORT_PROPERTIES = List.of(
+        SubjectLimitViolationEntity.Fields.subjectId,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitType,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitName,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limit,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.value,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.loading,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.acceptableDuration,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + ContingencyLimitViolationEntity.Fields.contingency + SpecificationUtils.FIELD_SEPARATOR + ContingencyEntity.Fields.contingencyId,
+        SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + ContingencyLimitViolationEntity.Fields.contingency + SpecificationUtils.FIELD_SEPARATOR + ContingencyEntity.Fields.status
+    );
 
     private static final List<String> ALLOWED_PRECONTINGENCIES_RESULT_SORT_PROPERTIES = List.of(
         AbstractLimitViolationEntity.Fields.subjectLimitViolation + SpecificationUtils.FIELD_SEPARATOR + SubjectLimitViolationEntity.Fields.subjectId,
@@ -270,7 +288,7 @@ public class SecurityAnalysisResultService {
     public Page<ContingencyEntity> findContingenciesPage(UUID resultUuid, List<ResourceFilterDTO> resourceFilters, Pageable pageable) {
         Objects.requireNonNull(resultUuid);
         assertNmKContingenciesSortAllowed(pageable.getSort());
-        Pageable modifiedPageable = addDefaultSort(pageable, DEFAULT_CONTINGENCY_SORT_COLUMN);
+        Pageable modifiedPageable = addDefaultSortAndRemoveChildrenSorting(pageable, ContingencyEntity.Fields.uuid);
 
         Specification<ContingencyEntity> specification = contingencySpecificationBuilder.buildSpecification(resultUuid, resourceFilters);
         // WARN org.hibernate.hql.internal.ast.QueryTranslatorImpl -
@@ -293,7 +311,7 @@ public class SecurityAnalysisResultService {
             // Then we fetch the main entities data for each UUID
             List<ContingencyEntity> contingencies = contingencyRepository.findAllByUuidIn(uuids);
             contingencies.sort(Comparator.comparing(c -> uuids.indexOf(c.getUuid())));
-            Page<ContingencyEntity> contingenciesPage = new PageImpl<>(contingencies, modifiedPageable, uuidPage.getTotalElements());
+            Page<ContingencyEntity> contingenciesPage = new PageImpl<>(contingencies, pageable, uuidPage.getTotalElements());
 
             // then we append the missing data, and filter some of the Lazy Loaded collections
             appendLimitViolationsAndElementsToContingenciesResult(contingenciesPage, resourceFilters);
@@ -306,7 +324,7 @@ public class SecurityAnalysisResultService {
     public Page<SubjectLimitViolationEntity> findSubjectLimitViolationsPage(UUID resultUuid, List<ResourceFilterDTO> resourceFilters, Pageable pageable) {
         Objects.requireNonNull(resultUuid);
         assertNmKSubjectLimitViolationsSortAllowed(pageable.getSort());
-        Pageable modifiedPageable = addDefaultSort(pageable, DEFAULT_SUBJECT_LIMIT_VIOLATION_SORT_COLUMN);
+        Pageable modifiedPageable = addDefaultSortAndRemoveChildrenSorting(pageable, SubjectLimitViolationEntity.Fields.id);
         Specification<SubjectLimitViolationEntity> specification = subjectLimitViolationSpecificationBuilder.buildSpecification(resultUuid, resourceFilters);
         // WARN org.hibernate.hql.internal.ast.QueryTranslatorImpl -
         // HHH000104: firstResult/maxResults specified with collection fetch; applying in memory!
@@ -347,6 +365,8 @@ public class SecurityAnalysisResultService {
             contingencyRepository.findAll(specification);
             // we fetch contingencyElements here to prevent N+1 query
             contingencyRepository.findAllWithContingencyElementsByUuidIn(contingencyUuids);
+
+            sortLimitViolationsInContingencies(contingencies);
         }
     }
 
@@ -366,13 +386,114 @@ public class SecurityAnalysisResultService {
                 .toList();
             // we fetch contingencyElements for each contingency here to prevent N+1 query
             contingencyRepository.findAllWithContingencyElementsByUuidIn(contingencyUuids);
+
+            sortLimitViolationsInSubjectLimitViolations(subjectLimitViolations);
         }
     }
 
-    private Pageable addDefaultSort(Pageable pageable, String defaultSortColumn) {
-        if (pageable.isPaged() && pageable.getSort().getOrderFor(defaultSortColumn) == null) {
+    private void sortLimitViolationsInContingencies(Page<ContingencyEntity> contingencies) {
+        Optional<Sort.Order> lvSortOrder = contingencies.getSort().get()
+            // we filter sort on nested limit violations
+            .filter(sortOrder ->
+                sortOrder.getProperty().startsWith(ContingencyEntity.Fields.contingencyLimitViolations))
+            // for now, only one children sort possible
+            .findFirst();
+
+        Comparator<ContingencyLimitViolationEntity> comparator = getLimitViolationComparatorForContingencies(lvSortOrder);
+
+        boolean isSortOrderAscending = lvSortOrder.map(Sort.Order::isAscending).orElse(true);
+
+        contingencies.forEach(contingency -> contingency
+            .getContingencyLimitViolations()
+            .sort(isSortOrderAscending ?
+                comparator :
+                comparator.reversed()));
+    }
+
+    private void sortLimitViolationsInSubjectLimitViolations(Page<SubjectLimitViolationEntity> subjectLimitViolations) {
+        Optional<Sort.Order> lvSortOrder = subjectLimitViolations.getSort().get()
+            // we filter sort on nested limit violations
+            .filter(sortOrder ->
+                sortOrder.getProperty().startsWith(SubjectLimitViolationEntity.Fields.contingencyLimitViolations))
+            // for now, only one children sort possible
+            .findFirst();
+
+        Comparator<ContingencyLimitViolationEntity> comparator = getLimitViolationComparatorForSubjectLimitViolations(lvSortOrder);
+
+        boolean isSortOrderAscending = lvSortOrder.map(Sort.Order::isAscending).orElse(true);
+
+        subjectLimitViolations.forEach(subjectLimitViolation -> subjectLimitViolation
+            .getContingencyLimitViolations()
+            .sort(isSortOrderAscending ?
+                comparator :
+                comparator.reversed()));
+    }
+
+    private static Comparator<ContingencyLimitViolationEntity> getLimitViolationComparatorForContingencies(Optional<Sort.Order> lvSortOrder) {
+        if (lvSortOrder.isPresent()) {
+            String field = lvSortOrder.get().getProperty()
+                .replaceFirst(ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR, "");
+            return switch (field) {
+                case AbstractLimitViolationEntity.Fields.subjectLimitViolation
+                    + SpecificationUtils.FIELD_SEPARATOR
+                    + SubjectLimitViolationEntity.Fields.subjectId ->
+                    Comparator.comparing(value -> value.getSubjectLimitViolation().getSubjectId(), Comparator.nullsLast(Comparator.naturalOrder()));
+                default -> getCommonComparator(field);
+            };
+        } else {
+            return Comparator.comparing(limitViolation -> limitViolation.getSubjectLimitViolation().getSubjectId());
+        }
+    }
+
+    private static Comparator<ContingencyLimitViolationEntity> getLimitViolationComparatorForSubjectLimitViolations(Optional<Sort.Order> lvSortOrder) {
+        if (lvSortOrder.isPresent()) {
+            String field = lvSortOrder.get().getProperty()
+                .replaceFirst(SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR, "");
+            return switch (field) {
+                case ContingencyLimitViolationEntity.Fields.contingency
+                    + SpecificationUtils.FIELD_SEPARATOR
+                    + ContingencyEntity.Fields.contingencyId ->
+                    Comparator.comparing(value -> value.getContingency().getContingencyId(), Comparator.nullsLast(Comparator.naturalOrder()));
+                case ContingencyLimitViolationEntity.Fields.contingency
+                    + SpecificationUtils.FIELD_SEPARATOR
+                    + ContingencyEntity.Fields.status ->
+                    Comparator.comparing(value -> value.getContingency().getStatus(), Comparator.nullsLast(Comparator.naturalOrder()));
+                default -> getCommonComparator(field);
+            };
+        } else {
+            return Comparator.comparing(limitViolation -> limitViolation.getContingency().getContingencyId());
+        }
+    }
+
+    private static Comparator<ContingencyLimitViolationEntity> getCommonComparator(String field) {
+        return switch (field) {
+            case AbstractLimitViolationEntity.Fields.limit ->
+                Comparator.comparing(AbstractLimitViolationEntity::getLimit, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.limitName ->
+                Comparator.comparing(AbstractLimitViolationEntity::getLimitName, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.limitType ->
+                Comparator.comparing(AbstractLimitViolationEntity::getLimitType, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.acceptableDuration ->
+                Comparator.comparing(AbstractLimitViolationEntity::getAcceptableDuration, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.value ->
+                Comparator.comparing(AbstractLimitViolationEntity::getValue, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.side ->
+                Comparator.comparing(AbstractLimitViolationEntity::getSide, Comparator.nullsLast(Comparator.naturalOrder()));
+            case AbstractLimitViolationEntity.Fields.loading ->
+                Comparator.comparing(AbstractLimitViolationEntity::getLoading, Comparator.nullsLast(Comparator.naturalOrder()));
+            default -> throw new IllegalArgumentException("Sorting on the column '" + field + "' is not supported"); // not supposed to happen
+        };
+    }
+
+    private Pageable addDefaultSortAndRemoveChildrenSorting(Pageable pageable, String defaultSortColumn) {
+        if (pageable.isPaged()) {
+            // Can't use both distinct and sort on nested field here, so we have to remove "children" sorting. Maybe there is a way to do it ?
+            // https://github.com/querydsl/querydsl/issues/2443
+            Sort finalSort = Sort.by(pageable.getSort().filter(sortOrder -> !sortOrder.getProperty().startsWith("contingencyLimitViolations")).toList());
             //if it's already sorted by our defaultColumn we don't add another sort by the same column
-            Sort finalSort = pageable.getSort().and(Sort.by(DEFAULT_SORT_DIRECTION, defaultSortColumn));
+            if (finalSort.getOrderFor(defaultSortColumn) == null) {
+                finalSort = finalSort.and(Sort.by(DEFAULT_SORT_DIRECTION, defaultSortColumn));
+            }
             return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), finalSort);
         }
         //nothing to do if the request is not paged

--- a/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
@@ -72,6 +72,7 @@ class FindContingenciesTest {
         "providePageableAndSortOnly",
         "provideParentFilter",
         "provideChildFilter",
+        "provideChildSorting",
         "provideEachColumnFilter",
         "provideCollectionOfFilters",
         "provideEdgeCasesFilters"
@@ -136,6 +137,60 @@ class FindContingenciesTest {
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.CONTAINS, "not_found", ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.subjectLimitViolation + SpecificationUtils.FIELD_SEPARATOR + SubjectLimitViolationEntity.Fields.subjectId)), PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
                 List.of(), 1) // filter by not found limit_violation
         );
+    }
+
+    private Stream<Arguments> provideChildSorting() {
+        return Stream.of(
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.subjectLimitViolation + SpecificationUtils.FIELD_SEPARATOR + SubjectLimitViolationEntity.Fields.subjectId),
+                Comparator.comparing(SubjectLimitViolationDTO::getSubjectId, Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limit),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimit(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitName),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimitName(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitType),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimitType(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.value),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getValue(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.loading),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLoading(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.acceptableDuration),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getAcceptableDuration(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getSide(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            // default sorting
+            buildArgumentsForChildrenSorting(
+                Sort.unsorted(),
+                Comparator.comparing(SubjectLimitViolationDTO::getSubjectId, Comparator.nullsLast(Comparator.naturalOrder()))
+            )
+        );
+    }
+
+    private Arguments buildArgumentsForChildrenSorting(Sort childrenSort, Comparator<SubjectLimitViolationDTO> childrenComparator) {
+        return Arguments.of(
+            List.of(),
+            PageRequest.of(0, 5,
+                Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)
+                    .and(childrenSort)),
+            getResultContingenciesSorted(
+                childrenComparator,
+                Comparator.comparing(this::getContingencyResultDTOId))
+                .subList(0, 5), 5);
     }
 
     private Stream<Arguments> provideEachColumnFilter() {

--- a/src/test/java/org/gridsuite/securityanalysis/server/FindSubjectLimitViolationsTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/FindSubjectLimitViolationsTest.java
@@ -8,10 +8,7 @@ package org.gridsuite.securityanalysis.server;
 
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.security.LimitViolationType;
-import org.gridsuite.securityanalysis.server.dto.ContingencyLimitViolationDTO;
-import org.gridsuite.securityanalysis.server.dto.ResourceFilterDTO;
-import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisStatus;
-import org.gridsuite.securityanalysis.server.dto.SubjectLimitViolationResultDTO;
+import org.gridsuite.securityanalysis.server.dto.*;
 import org.gridsuite.securityanalysis.server.entities.*;
 import org.gridsuite.securityanalysis.server.repositories.SecurityAnalysisResultRepository;
 import org.gridsuite.securityanalysis.server.repositories.specifications.SpecificationUtils;
@@ -72,6 +69,7 @@ class FindSubjectLimitViolationsTest {
         "providePageableAndSortOnly",
         "provideParentFilter",
         "provideChildFilter",
+        "provideChildSorting",
         "provideEachColumnFilter"
     })
     void findFilteredSubjectLimitViolationResultsTest(List<ResourceFilterDTO> filters, Pageable pageable, List<SubjectLimitViolationResultDTO> expectedResult, Integer expectedSelectCount) {
@@ -134,6 +132,64 @@ class FindSubjectLimitViolationsTest {
                     .stream().sorted(Comparator.comparing(SubjectLimitViolationResultDTO::getSubjectId)).toList()
                     .subList(0, 2), 5)
         );
+    }
+
+    private Stream<Arguments> provideChildSorting() {
+        return Stream.of(
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + ContingencyLimitViolationEntity.Fields.contingency + SpecificationUtils.FIELD_SEPARATOR + ContingencyEntity.Fields.contingencyId),
+                Comparator.comparing(c -> c.getContingency().getContingencyId(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + ContingencyLimitViolationEntity.Fields.contingency + SpecificationUtils.FIELD_SEPARATOR + ContingencyEntity.Fields.status),
+                Comparator.comparing(c -> c.getContingency().getStatus(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limit),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimit(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitName),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimitName(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitType),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLimitType(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.value),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getValue(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.loading),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getLoading(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.acceptableDuration),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getAcceptableDuration(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            buildArgumentsForChildrenSorting(
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side),
+                Comparator.comparing(subjectLimitViolationDTO -> subjectLimitViolationDTO.getLimitViolation().getSide(), Comparator.nullsLast(Comparator.naturalOrder()))
+            ),
+            // default sorting
+            buildArgumentsForChildrenSorting(
+                Sort.unsorted(),
+                Comparator.comparing(c -> c.getContingency().getContingencyId(), Comparator.nullsLast(Comparator.naturalOrder()))
+            )
+        );
+    }
+
+    private Arguments buildArgumentsForChildrenSorting(Sort childrenSort, Comparator<ContingencyLimitViolationDTO> childrenComparator) {
+        return Arguments.of(
+            List.of(),
+            PageRequest.of(0, 4,
+                Sort.by(Sort.Direction.ASC, SubjectLimitViolationEntity.Fields.subjectId)
+                    .and(childrenSort)),
+            getResultConstraintsSorted(
+                childrenComparator,
+                Comparator.comparing(SubjectLimitViolationResultDTO::getSubjectId))
+                .subList(0, 4), 5);
     }
 
     private Stream<Arguments> provideEachColumnFilter() {

--- a/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
@@ -164,7 +164,7 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
     }
 
     static List<SubjectLimitViolationResultDTO> getResultConstraintsSorted(Comparator<ContingencyLimitViolationDTO> limitViolationDTOComparator,
-                                                                                     Comparator<SubjectLimitViolationResultDTO> contingencyResultDTOComparator) {
+                                                                           Comparator<SubjectLimitViolationResultDTO> subjectLimitViolationResultDTOComparator) {
         return RESULT_CONSTRAINTS.stream().map(r ->
                 new SubjectLimitViolationResultDTO(
                     r.getSubjectId(),
@@ -172,7 +172,7 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
                         .sorted(limitViolationDTOComparator)
                         .toList()
                 ))
-            .sorted(contingencyResultDTOComparator)
+            .sorted(subjectLimitViolationResultDTOComparator)
             .toList();
     }
 

--- a/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
@@ -22,6 +22,7 @@ import org.gridsuite.securityanalysis.server.dto.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -130,6 +131,19 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
             .toList();
     }
 
+    static List<ContingencyResultDTO> getResultContingenciesSorted(Comparator<SubjectLimitViolationDTO> limitViolationDTOComparator,
+                                                                   Comparator<ContingencyResultDTO> contingencyResultDTOComparator) {
+        return RESULT_CONTINGENCIES.stream().map(r ->
+                new ContingencyResultDTO(
+                    r.getContingency(),
+                    r.getSubjectLimitViolations().stream()
+                        .sorted(limitViolationDTOComparator)
+                        .toList()
+                ))
+            .sorted(contingencyResultDTOComparator)
+            .toList();
+    }
+
     static final List<SubjectLimitViolationResultDTO> RESULT_CONSTRAINTS = Stream.concat(
         RESULT_LIMIT_VIOLATIONS.stream()
             .map(limitViolation -> toSubjectLimitViolationResultDTO(limitViolation, CONTINGENCIES.stream().map(ContingencyInfos::getContingency).collect(Collectors.toList()), LoadFlowResult.ComponentResult.Status.CONVERGED)),
@@ -146,6 +160,19 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
                     .toList()
             ))
             .filter(r -> !r.getContingencies().isEmpty())
+            .toList();
+    }
+
+    static List<SubjectLimitViolationResultDTO> getResultConstraintsSorted(Comparator<ContingencyLimitViolationDTO> limitViolationDTOComparator,
+                                                                                     Comparator<SubjectLimitViolationResultDTO> contingencyResultDTOComparator) {
+        return RESULT_CONSTRAINTS.stream().map(r ->
+                new SubjectLimitViolationResultDTO(
+                    r.getSubjectId(),
+                    r.getContingencies().stream()
+                        .sorted(limitViolationDTOComparator)
+                        .toList()
+                ))
+            .sorted(contingencyResultDTOComparator)
             .toList();
     }
 


### PR DESCRIPTION
Allow to sort limit violations in contingencies and subject limit violations by the specified field in the sorting order.