### PR TITLE
Fix getResult() when no nmk contigencies

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
@@ -151,10 +151,13 @@ public class SecurityAnalysisController {
                                                                                     @Parameter(description = "Pagination parameters") Pageable pageable) {
         String decodedStringFilters = stringFilters != null ? URLDecoder.decode(stringFilters, StandardCharsets.UTF_8) : null;
         Page<ContingencyResultDTO> result = securityAnalysisResultService.findNmKContingenciesPaged(resultUuid, decodedStringFilters, pageable);
-
-        return result != null
-            ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result)
-            : ResponseEntity.notFound().build();
+        if (result == null) {
+            return ResponseEntity.notFound().build();
+        } else if (result.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
+        }
     }
 
     @PostMapping(value = "/results/{resultUuid}/nmk-contingencies-result/csv", produces = APPLICATION_OCTET_STREAM_VALUE, consumes = APPLICATION_JSON_VALUE)

--- a/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
@@ -151,6 +151,7 @@ public class SecurityAnalysisController {
                                                                                     @Parameter(description = "Pagination parameters") Pageable pageable) {
         String decodedStringFilters = stringFilters != null ? URLDecoder.decode(stringFilters, StandardCharsets.UTF_8) : null;
         Page<ContingencyResultDTO> result = securityAnalysisResultService.findNmKContingenciesPaged(resultUuid, decodedStringFilters, pageable);
+
         return result != null
             ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result)
             : ResponseEntity.notFound().build();

--- a/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
@@ -152,8 +152,8 @@ public class SecurityAnalysisController {
         String decodedStringFilters = stringFilters != null ? URLDecoder.decode(stringFilters, StandardCharsets.UTF_8) : null;
         Page<ContingencyResultDTO> result = securityAnalysisResultService.findNmKContingenciesPaged(resultUuid, decodedStringFilters, pageable);
         return result != null
-                ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result)
-                : ResponseEntity.notFound().build();
+            ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result)
+            : ResponseEntity.notFound().build();
     }
 
     @PostMapping(value = "/results/{resultUuid}/nmk-contingencies-result/csv", produces = APPLICATION_OCTET_STREAM_VALUE, consumes = APPLICATION_JSON_VALUE)

--- a/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/SecurityAnalysisController.java
@@ -151,13 +151,9 @@ public class SecurityAnalysisController {
                                                                                     @Parameter(description = "Pagination parameters") Pageable pageable) {
         String decodedStringFilters = stringFilters != null ? URLDecoder.decode(stringFilters, StandardCharsets.UTF_8) : null;
         Page<ContingencyResultDTO> result = securityAnalysisResultService.findNmKContingenciesPaged(resultUuid, decodedStringFilters, pageable);
-        if (result == null) {
-            return ResponseEntity.notFound().build();
-        } else if (result.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        } else {
-            return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result);
-        }
+        return result != null
+                ? ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(result)
+                : ResponseEntity.notFound().build();
     }
 
     @PostMapping(value = "/results/{resultUuid}/nmk-contingencies-result/csv", produces = APPLICATION_OCTET_STREAM_VALUE, consumes = APPLICATION_JSON_VALUE)

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -138,6 +138,9 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         assertResultExists(resultUuid);
 
         Page<ContingencyEntity> contingencyPageBis = self.findContingenciesPage(resultUuid, fromStringFiltersToDTO(stringFilters), pageable);
+        if (contingencyPageBis.isEmpty()) {
+            return Page.empty();
+        }
         return contingencyPageBis.map(ContingencyResultDTO::toDto);
     }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -138,9 +138,6 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         assertResultExists(resultUuid);
 
         Page<ContingencyEntity> contingencyPageBis = self.findContingenciesPage(resultUuid, fromStringFiltersToDTO(stringFilters), pageable);
-        if (contingencyPageBis.isEmpty()) {
-            return Page.empty();
-        }
         return contingencyPageBis.map(ContingencyResultDTO::toDto);
     }
 
@@ -290,6 +287,10 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         return securityAnalysisResult.get().getStatus();
     }
 
+    private static Page emptyPage() {
+        return new PageImpl(List.of(), Pageable.unpaged(), 0);
+    }
+
     @Transactional(readOnly = true)
     public Page<ContingencyEntity> findContingenciesPage(UUID resultUuid, List<ResourceFilterDTO> resourceFilters, Pageable pageable) {
         Objects.requireNonNull(resultUuid);
@@ -311,7 +312,8 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         );
 
         if (!uuidPage.hasContent()) {
-            return Page.empty();
+            // Since springboot 3.2, the return value of Page.empty() is not serializable. See https://github.com/spring-projects/spring-data-commons/issues/2987
+            return emptyPage();
         } else {
             List<UUID> uuids = uuidPage.map(ContingencyRepository.EntityUuid::getUuid).toList();
             // Then we fetch the main entities data for each UUID
@@ -344,7 +346,8 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         );
 
         if (!uuidPage.hasContent()) {
-            return Page.empty();
+            // Since springboot 3.2, the return value of Page.empty() is not serializable. See https://github.com/spring-projects/spring-data-commons/issues/2987
+            return emptyPage();
         } else {
             List<UUID> uuids = uuidPage.map(u -> u.getId()).toList();
             // Then we fetch the main entities data for each UUID

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -287,8 +287,8 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         return securityAnalysisResult.get().getStatus();
     }
 
-    private static Page emptyPage() {
-        return new PageImpl(List.of(), Pageable.unpaged(), 0);
+    private static Page<?> emptyPage(Pageable pageable) {
+        return new PageImpl<>(List.of(), pageable, 0);
     }
 
     @Transactional(readOnly = true)
@@ -313,7 +313,7 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
 
         if (!uuidPage.hasContent()) {
             // Since springboot 3.2, the return value of Page.empty() is not serializable. See https://github.com/spring-projects/spring-data-commons/issues/2987
-            return emptyPage();
+            return (Page<ContingencyEntity>) emptyPage(pageable);
         } else {
             List<UUID> uuids = uuidPage.map(ContingencyRepository.EntityUuid::getUuid).toList();
             // Then we fetch the main entities data for each UUID
@@ -347,7 +347,7 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
 
         if (!uuidPage.hasContent()) {
             // Since springboot 3.2, the return value of Page.empty() is not serializable. See https://github.com/spring-projects/spring-data-commons/issues/2987
-            return emptyPage();
+            return (Page<SubjectLimitViolationEntity>) emptyPage(pageable);
         } else {
             List<UUID> uuids = uuidPage.map(u -> u.getId()).toList();
             // Then we fetch the main entities data for each UUID


### PR DESCRIPTION
Bug introduced by [springboot 3.3 upgrade](https://github.com/gridsuite/security-analysis-server/commit/40768a889a95099736e319d269083ce3b2ddc44d) 

Springboot cannot deserialize anymore Page.empty(). See: https://github.com/spring-projects/spring-data-commons/issues/2987