### PR TITLE
fix no contingency list exception

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/error/AllContingencyListMissingException.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/error/AllContingencyListMissingException.java
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2026, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.gridsuite.securityanalysis.server.error;
+
+/**
+ * @author Etienne Lesot <etienne.lesot at rte-france.com>
+ */
+public class AllContingencyListMissingException extends IllegalArgumentException {
+    public AllContingencyListMissingException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/ActionsService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/ActionsService.java
@@ -47,9 +47,8 @@ public class ActionsService {
     }
 
     public List<ContingencyInfos> getContingencyList(List<UUID> ids, UUID networkUuid, String variantId) {
-        Objects.requireNonNull(ids);
         Objects.requireNonNull(networkUuid);
-        if (ids.isEmpty()) {
+        if (ids == null || ids.isEmpty()) {
             throw new AllContingencyListMissingException("There is no contingency list selected");
         }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/ActionsService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/ActionsService.java
@@ -7,6 +7,7 @@
 package org.gridsuite.securityanalysis.server.service;
 
 import org.gridsuite.securityanalysis.server.dto.ContingencyInfos;
+import org.gridsuite.securityanalysis.server.error.AllContingencyListMissingException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
@@ -49,7 +50,7 @@ public class ActionsService {
         Objects.requireNonNull(ids);
         Objects.requireNonNull(networkUuid);
         if (ids.isEmpty()) {
-            throw new IllegalArgumentException("List 'ids' must not be null or empty");
+            throw new AllContingencyListMissingException("There is no contingency list selected");
         }
 
         URI path = UriComponentsBuilder

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisWorkerService.java
@@ -33,6 +33,7 @@ import org.gridsuite.securityanalysis.server.dto.ContingencyInfos;
 import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisParametersDTO;
 import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisStatus;
 import org.gridsuite.securityanalysis.server.dto.parameters.LimitReductionsByVoltageLevel;
+import org.gridsuite.securityanalysis.server.error.AllContingencyListMissingException;
 import org.gridsuite.securityanalysis.server.error.SecurityAnalysisBusinessErrorCode;
 import org.gridsuite.securityanalysis.server.error.SecurityAnalysisException;
 import org.gridsuite.securityanalysis.server.util.SecurityAnalysisRunnerSupplier;
@@ -177,7 +178,7 @@ public class SecurityAnalysisWorkerService extends AbstractWorkerService<Securit
                             actionsService.getContingencyList(runContext.getParameters().contingencyListUuids(), runContext.getNetworkUuid(), runContext.getVariantId())
             );
             runContext.setContingencies(contingencies);
-        } catch (IllegalArgumentException e) {
+        } catch (AllContingencyListMissingException e) {
             throw new SecurityAnalysisException(SecurityAnalysisBusinessErrorCode.CONTINGENCY_LIST_CONFIG_EMPTY, "The configuration does not contain any contingency.");
         } catch (HttpClientErrorException.NotFound e) {
             throw new SecurityAnalysisException(SecurityAnalysisBusinessErrorCode.MISSING_CONTINGENCY_LIST, "The configuration contains one or more contingency lists that have been deleted.");

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
@@ -17,6 +17,7 @@ import mockwebserver3.junit5.internal.MockWebServerExtension;
 import okhttp3.Headers;
 import okhttp3.HttpUrl;
 import org.gridsuite.securityanalysis.server.dto.ContingencyInfos;
+import org.gridsuite.securityanalysis.server.error.AllContingencyListMissingException;
 import org.gridsuite.securityanalysis.server.util.ContextConfigurationWithTestChannel;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,16 +30,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
@@ -93,7 +90,7 @@ class ActionsServiceTest {
                 } else if (requestPath.equals(String.format("/v1/contingency-lists/contingency-infos/export?networkUuid=%s&ids=%s", NETWORK_UUID, LIST_UUID))) {
                     return new MockResponse(HttpStatus.OK.value(), Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), jsonExpected);
                 } else if (requestPath.equals(String.format("/v1/contingency-lists/contingency-infos/export?networkUuid=%s&variantId=%s&ids=%s", NETWORK_UUID, VARIANT_ID, VERY_LARGE_LIST_UUID))
-                           || requestPath.equals(String.format("/v1/contingency-lists/contingency-infos/export?networkUuid=%s&ids=%s", NETWORK_UUID, VERY_LARGE_LIST_UUID))) {
+                        || requestPath.equals(String.format("/v1/contingency-lists/contingency-infos/export?networkUuid=%s&ids=%s", NETWORK_UUID, VERY_LARGE_LIST_UUID))) {
                     return new MockResponse(HttpStatus.OK.value(), Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), veryLargeJsonExpected);
                 } else if (requestPath.equals(String.format("/v1/contingency-lists/contingency-infos/export?networkUuid=%s&ids=%s&ids=%s", NETWORK_UUID, LIST_UUID, LIST_UUID_VARIANT))) {
                     return new MockResponse(HttpStatus.OK.value(), Headers.of(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE), jsonExpectedForList);
@@ -138,5 +135,14 @@ class ActionsServiceTest {
     void testGetContingenciesByListOfIds() {
         List<ContingencyInfos> list = actionsService.getContingencyList(List.of(LIST_UUID, LIST_UUID_VARIANT), UUID.fromString(NETWORK_UUID), null);
         assertEquals(Stream.of(CONTINGENCY, CONTINGENCY_VARIANT).map(ContingencyInfos::getContingency).toList(), list.stream().map(ContingencyInfos::getContingency).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testErrors() {
+        String expectedMessage = "There is no contingency list selected";
+        String message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(null, UUID.fromString(NETWORK_UUID), null)).getMessage();
+        assertEquals(expectedMessage, message);
+        message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(Collections.emptyList(), UUID.fromString(NETWORK_UUID), null)).getMessage();
+        assertEquals(expectedMessage, message);
     }
 }

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
@@ -143,7 +143,8 @@ class ActionsServiceTest {
         UUID networkUuid = UUID.fromString(NETWORK_UUID);
         String message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(null, networkUuid, null)).getMessage();
         assertEquals(expectedMessage, message);
-        message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(Collections.emptyList(), networkUuid, null)).getMessage();
+        List<UUID> emptyList = Collections.emptyList();
+        message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(emptyList, networkUuid, null)).getMessage();
         assertEquals(expectedMessage, message);
     }
 }

--- a/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/service/ActionsServiceTest.java
@@ -140,9 +140,10 @@ class ActionsServiceTest {
     @Test
     void testErrors() {
         String expectedMessage = "There is no contingency list selected";
-        String message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(null, UUID.fromString(NETWORK_UUID), null)).getMessage();
+        UUID networkUuid = UUID.fromString(NETWORK_UUID);
+        String message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(null, networkUuid, null)).getMessage();
         assertEquals(expectedMessage, message);
-        message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(Collections.emptyList(), UUID.fromString(NETWORK_UUID), null)).getMessage();
+        message = assertThrows(AllContingencyListMissingException.class, () -> actionsService.getContingencyList(Collections.emptyList(), networkUuid, null)).getMessage();
         assertEquals(expectedMessage, message);
     }
 }


### PR DESCRIPTION
## PR Summary
if an illegal exception is thrown the error is 'there is no contingency list'. So to avoid to hide exceptions, a new exception AllContingencyListMissingException is created and caught.



