### PR TITLE
Fix global filtering in contingencies results

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/entities/ContingencyElementEmbeddable.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/entities/ContingencyElementEmbeddable.java
@@ -14,6 +14,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.FieldNameConstants;
 
 /**
  * @author Laurent GARNIER <laurent.garnier at rte-france.com>
@@ -23,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Embeddable
+@FieldNameConstants
 public class ContingencyElementEmbeddable {
 
     @Column

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -43,7 +43,10 @@ public class FilterService extends AbstractFilterService {
             List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.THREE_WINDINGS_TRANSFORMER,
                 EquipmentType.BATTERY, EquipmentType.GENERATOR, EquipmentType.LOAD, EquipmentType.SHUNT_COMPENSATOR,
                 EquipmentType.STATIC_VAR_COMPENSATOR,
-                EquipmentType.BOUNDARY_LINE, EquipmentType.HVDC_LINE, EquipmentType.VSC_CONVERTER_STATION),
+                EquipmentType.BOUNDARY_LINE,
+                // TODO : temporary removed, waiting for a fix in filter library on nominal voltage filtering for hvdc line
+                // EquipmentType.HVDC_LINE,
+                EquipmentType.VSC_CONVERTER_STATION),
             "contingencyElements.elementId");
     }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -12,7 +12,6 @@ import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.service.AbstractFilterService;
 import org.gridsuite.filter.utils.EquipmentType;
-import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.entities.SubjectLimitViolationEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -39,10 +38,17 @@ public class FilterService extends AbstractFilterService {
     }
 
     public Optional<ResourceFilterDTO> getResourceFilterContingencies(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {
-        return super.getResourceFilter(networkUuid, variantId, globalFilter, List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.VOLTAGE_LEVEL), ContingencyEntity.Fields.contingencyId);
+        return super.getResourceFilter(networkUuid,
+            variantId, globalFilter,
+            List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.THREE_WINDINGS_TRANSFORMER,
+                EquipmentType.BATTERY, EquipmentType.GENERATOR, EquipmentType.LOAD, EquipmentType.SHUNT_COMPENSATOR,
+                EquipmentType.STATIC_VAR_COMPENSATOR,
+                EquipmentType.BOUNDARY_LINE, EquipmentType.HVDC_LINE, EquipmentType.VSC_CONVERTER_STATION),
+            "contingencyElements.elementId");
     }
 
     public Optional<ResourceFilterDTO> getResourceFilterSubjectLimitViolations(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {
-        return super.getResourceFilter(networkUuid, variantId, globalFilter, List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.VOLTAGE_LEVEL), SubjectLimitViolationEntity.Fields.subjectId);
+        return super.getResourceFilter(networkUuid, variantId, globalFilter, List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.VOLTAGE_LEVEL),
+            SubjectLimitViolationEntity.Fields.subjectId);
     }
 }

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -12,6 +12,8 @@ import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.service.AbstractFilterService;
 import org.gridsuite.filter.utils.EquipmentType;
+import org.gridsuite.securityanalysis.server.entities.ContingencyElementEmbeddable;
+import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.entities.SubjectLimitViolationEntity;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -20,6 +22,8 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import static org.gridsuite.computation.utils.SpecificationUtils.FIELD_SEPARATOR;
 
 /**
  * @author Rehili Ghazwa <ghazwa.rehili at rte-france.com>
@@ -47,7 +51,7 @@ public class FilterService extends AbstractFilterService {
                 // TODO : temporary removed, waiting for a fix in filter library on nominal voltage filtering for hvdc line
                 // EquipmentType.HVDC_LINE,
                 EquipmentType.VSC_CONVERTER_STATION),
-            "contingencyElements.elementId");
+            ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId);
     }
 
     public Optional<ResourceFilterDTO> getResourceFilterSubjectLimitViolations(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Fix global filtering for contingencies in N-K results, in order to use the equipments ids in the contingency instead of the contingency id.

