### PR TITLE
Fix bad nmk contingencies results when no resource filters found

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -167,8 +167,13 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         assertResultExists(resultUuid);
 
         List<ResourceFilterDTO> allResourceFilters = getAllResourceFilters(stringFilters, stringGlobalFilters, globalFilter -> filterService.getResourceFilterContingencies(networkUuid, variantId, globalFilter));
-        Page<ContingencyEntity> contingencyPageBis = self.findContingenciesPage(resultUuid, allResourceFilters, pageable);
-        return contingencyPageBis.map(ContingencyResultDTO::toDto);
+        if (stringGlobalFilters != null && allResourceFilters.isEmpty()) {
+            // something is checked in the global filter but no resource filters are returned
+            return Page.empty(pageable);
+        } else {
+            Page<ContingencyEntity> contingencyPageBis = self.findContingenciesPage(resultUuid, allResourceFilters, pageable);
+            return contingencyPageBis.map(ContingencyResultDTO::toDto);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -169,7 +169,7 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
         List<ResourceFilterDTO> allResourceFilters = getAllResourceFilters(stringFilters, stringGlobalFilters, globalFilter -> filterService.getResourceFilterContingencies(networkUuid, variantId, globalFilter));
         if (stringGlobalFilters != null && allResourceFilters.isEmpty()) {
             // something is checked in the global filter but no resource filters are returned
-            return Page.empty(pageable);
+            return (Page<ContingencyResultDTO>) emptyPage(pageable);
         } else {
             Page<ContingencyEntity> contingencyPageBis = self.findContingenciesPage(resultUuid, allResourceFilters, pageable);
             return contingencyPageBis.map(ContingencyResultDTO::toDto);


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

For N-K contingencies results, when something is checked in the global filter, but no resource filter objects are returned, we got the same results (the whole contingencies results) as if nothing was checked in the global filter.




