### PR TITLE
Add busbar section equipement type to filter busbar sections contingencies, using voltage level filters in the generic filters category

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <sonar.projectKey>org.gridsuite:security-analysis-server</sonar.projectKey>
         <!-- FIXME: to be removed at next gridsuite-dependencies upgrade  -->
         <gridsuite-computation.version>2.3.0</gridsuite-computation.version>
-        <gridsuite-filter.version>1.26.0</gridsuite-filter.version>
+        <gridsuite-filter.version>1.27.0-SNAPSHOT</gridsuite-filter.version>
     </properties>
 
     <build>

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -49,7 +49,8 @@ public class FilterService extends AbstractFilterService {
                 EquipmentType.STATIC_VAR_COMPENSATOR,
                 EquipmentType.BOUNDARY_LINE,
                 EquipmentType.HVDC_LINE,
-                EquipmentType.VSC_CONVERTER_STATION),
+                EquipmentType.VSC_CONVERTER_STATION,
+                EquipmentType.BUSBAR_SECTION),
             ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId);
     }
 

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -56,13 +56,15 @@ public class FilterService extends AbstractFilterService {
 
     public Optional<ResourceFilterDTO> getResourceFilterCutOffPower(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {
         return super.getResourceFilter(networkUuid,
-                variantId, globalFilter,
-                List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.THREE_WINDINGS_TRANSFORMER,
-                        EquipmentType.BATTERY, EquipmentType.GENERATOR, EquipmentType.LOAD, EquipmentType.SHUNT_COMPENSATOR,
-                        EquipmentType.STATIC_VAR_COMPENSATOR,
-                        EquipmentType.BOUNDARY_LINE,
-                        EquipmentType.VSC_CONVERTER_STATION),
-                ContingencyEntity.Fields.contingencyId);
+            variantId, globalFilter,
+            List.of(EquipmentType.LINE, EquipmentType.TWO_WINDINGS_TRANSFORMER, EquipmentType.THREE_WINDINGS_TRANSFORMER,
+                EquipmentType.BATTERY, EquipmentType.GENERATOR, EquipmentType.LOAD, EquipmentType.SHUNT_COMPENSATOR,
+                EquipmentType.STATIC_VAR_COMPENSATOR,
+                EquipmentType.BOUNDARY_LINE,
+                EquipmentType.HVDC_LINE,
+                EquipmentType.VSC_CONVERTER_STATION,
+                EquipmentType.BUSBAR_SECTION),
+            ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId);
     }
 
     public Optional<ResourceFilterDTO> getResourceFilterSubjectLimitViolations(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

We want to filter contingencies on busbar sections in the security analysis results, using voltage level filters selected in the generic filters category.


Waiting for PR : https://github.com/gridsuite/filter/pull/122
