### PR TITLE
Fix global filtering for cut-off power results

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/FilterService.java
@@ -60,8 +60,9 @@ public class FilterService extends AbstractFilterService {
                         EquipmentType.BATTERY, EquipmentType.GENERATOR, EquipmentType.LOAD, EquipmentType.SHUNT_COMPENSATOR,
                         EquipmentType.STATIC_VAR_COMPENSATOR,
                         EquipmentType.BOUNDARY_LINE,
+                        EquipmentType.HVDC_LINE,
                         EquipmentType.VSC_CONVERTER_STATION),
-                ContingencyEntity.Fields.contingencyId);
+            ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId);
     }
 
     public Optional<ResourceFilterDTO> getResourceFilterSubjectLimitViolations(@NonNull UUID networkUuid, @NonNull String variantId, @NonNull GlobalFilter globalFilter) {


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

Fix global filtering for contingencies cutoff power results (similar as what was done in (https://github.com/gridsuite/security-analysis-server/pull/248)

