### PR TITLE
Remove duplicated elements in the contingencyLimitViolations list.

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.security.SecurityAnalysisResult;
 import lombok.Getter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.error.ComputationException;
@@ -557,6 +558,17 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
             contingencyRepository.findAll(specification);
             // we fetch contingencyElements here to prevent N+1 query
             contingencyRepository.findAllWithContingencyElementsByUuidIn(contingencyUuids);
+
+            // Removing the duplicated elements in the contingencyLimitViolations list of each contingency,
+            // preserving the order
+            contingencies.forEach(contingency -> {
+                List<ContingencyLimitViolationEntity> limitViolations = contingency.getContingencyLimitViolations();
+                if (!CollectionUtils.isEmpty(limitViolations)) {
+                    List<ContingencyLimitViolationEntity> uniqueLimitViolations = new ArrayList<>(new LinkedHashSet<>(limitViolations));
+                    limitViolations.clear();
+                    limitViolations.addAll(uniqueLimitViolations);
+                }
+            });
 
             sortLimitViolationsInContingencies(contingencies);
         }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

When filtering the security analysis n-k results using the global filter, the limit violations results may be duplicated in the case of multiple contingencies.



