### PR TITLE
Fix duplication when filtering on children

### DIFF
--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/specifications/ContingencySpecificationBuilder.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/specifications/ContingencySpecificationBuilder.java
@@ -29,7 +29,8 @@ import static org.gridsuite.computation.utils.SpecificationUtils.FIELD_SEPARATOR
 public class ContingencySpecificationBuilder extends AbstractCommonSpecificationBuilder<ContingencyEntity> {
     @Override
     public boolean isNotParentFilter(ResourceFilterDTO filter) {
-        return !List.of(ContingencyEntity.Fields.contingencyId, ContingencyEntity.Fields.status, ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId).contains(filter.column());
+        return !List.of(ContingencyEntity.Fields.contingencyId, ContingencyEntity.Fields.status,
+            ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId).contains(filter.column());
     }
 
     @Override

--- a/src/main/java/org/gridsuite/securityanalysis/server/repositories/specifications/ContingencySpecificationBuilder.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/repositories/specifications/ContingencySpecificationBuilder.java
@@ -12,12 +12,15 @@ import jakarta.persistence.criteria.Root;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.specification.AbstractCommonSpecificationBuilder;
 import org.gridsuite.computation.utils.SpecificationUtils;
+import org.gridsuite.securityanalysis.server.entities.ContingencyElementEmbeddable;
 import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.entities.SecurityAnalysisResultEntity;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.UUID;
+
+import static org.gridsuite.computation.utils.SpecificationUtils.FIELD_SEPARATOR;
 
 /**
  * @author Kevin LE SAULNIER <kevin.lesaulnier at rte-france.com>
@@ -26,7 +29,7 @@ import java.util.UUID;
 public class ContingencySpecificationBuilder extends AbstractCommonSpecificationBuilder<ContingencyEntity> {
     @Override
     public boolean isNotParentFilter(ResourceFilterDTO filter) {
-        return !List.of(ContingencyEntity.Fields.contingencyId, ContingencyEntity.Fields.status).contains(filter.column());
+        return !List.of(ContingencyEntity.Fields.contingencyId, ContingencyEntity.Fields.status, ContingencyEntity.Fields.contingencyElements + FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId).contains(filter.column());
     }
 
     @Override

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -559,17 +559,6 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
             // we fetch contingencyElements here to prevent N+1 query
             contingencyRepository.findAllWithContingencyElementsByUuidIn(contingencyUuids);
 
-            // Removing the duplicated elements in the contingencyLimitViolations list of each contingency,
-            // preserving the order
-            contingencies.forEach(contingency -> {
-                List<ContingencyLimitViolationEntity> limitViolations = contingency.getContingencyLimitViolations();
-                if (!CollectionUtils.isEmpty(limitViolations)) {
-                    List<ContingencyLimitViolationEntity> uniqueLimitViolations = new ArrayList<>(new LinkedHashSet<>(limitViolations));
-                    limitViolations.clear();
-                    limitViolations.addAll(uniqueLimitViolations);
-                }
-            });
-
             sortLimitViolationsInContingencies(contingencies);
         }
     }

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -12,6 +12,7 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.security.SecurityAnalysisResult;
 import lombok.Getter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.error.ComputationException;
@@ -557,6 +558,17 @@ public class SecurityAnalysisResultService extends AbstractComputationResultServ
             contingencyRepository.findAll(specification);
             // we fetch contingencyElements here to prevent N+1 query
             contingencyRepository.findAllWithContingencyElementsByUuidIn(contingencyUuids);
+
+            // Removing the duplicated elements in the contingencyLimitViolations list of each contingency,
+            // preserving the order
+            contingencies.forEach(contingency -> {
+                List<ContingencyLimitViolationEntity> limitViolations = contingency.getContingencyLimitViolations();
+                if (!CollectionUtils.isEmpty(limitViolations)) {
+                    List<ContingencyLimitViolationEntity> uniqueLimitViolations = new ArrayList<>(new LinkedHashSet<>(limitViolations));
+                    limitViolations.clear();
+                    limitViolations.addAll(uniqueLimitViolations);
+                }
+            });
 
             sortLimitViolationsInContingencies(contingencies);
         }

--- a/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
+++ b/src/main/java/org/gridsuite/securityanalysis/server/service/SecurityAnalysisResultService.java
@@ -12,7 +12,6 @@ import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeSides;
 import com.powsybl.security.SecurityAnalysisResult;
 import lombok.Getter;
-import org.apache.commons.collections4.CollectionUtils;
 import org.gridsuite.computation.dto.GlobalFilter;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.error.ComputationException;

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -22,3 +22,5 @@ gridsuite:
       base-uri: http://localhost:5028
     loadflow-server:
       base-uri: http://localhost:5008
+    filter-server:
+      base-uri: http://localhost:5027

--- a/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
@@ -67,7 +67,7 @@ class FindContingenciesTest {
     void setUp() {
         // network store service mocking
         Network network = EurostagTutorialExample1Factory.create(new NetworkFactoryImpl());
-        resultEntity = SecurityAnalysisResultEntity.toEntity(network, UUID.randomUUID(), RESULT, SecurityAnalysisStatus.CONVERGED);
+        resultEntity = SecurityAnalysisResultEntity.toEntity(network, UUID.randomUUID(), RESULT_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES, SecurityAnalysisStatus.CONVERGED);
         securityAnalysisResultRepository.save(resultEntity);
     }
 
@@ -119,9 +119,11 @@ class FindContingenciesTest {
     private static Stream<Arguments> providePageableAndSortOnly() {
         return Stream.of(
             Arguments.of(List.of(), PageRequest.of(0, 5, Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                    RESULT_CONTINGENCIES.stream().sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList().subList(0, 5), 5),
+                    RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream()
+                        .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList().subList(0, 5), 5),
             Arguments.of(List.of(), PageRequest.of(0, 5, Sort.by(Sort.Direction.DESC, ContingencyEntity.Fields.contingencyId)),
-                    RESULT_CONTINGENCIES.stream().sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId).reversed()).toList().subList(0, 5), 5)
+                    RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream()
+                        .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId).reversed()).toList().subList(0, 5), 5)
         );
     }
 
@@ -129,15 +131,18 @@ class FindContingenciesTest {
         return Stream.of(
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.CONTAINS, "3", ContingencyEntity.Fields.contingencyId)), PageRequest.of(0, 30,
                     Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getContingencyId().contains("3")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(),
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getContingencyId().contains("3"))
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(),
                         4),
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.STARTS_WITH, "l", ContingencyEntity.Fields.contingencyId)), PageRequest.of(0, 30,
                     Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getContingencyId().startsWith("l")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getContingencyId().startsWith("l"))
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(
                         ), 4),
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.STARTS_WITH, "3", ContingencyEntity.Fields.contingencyId)), PageRequest.of(0, 30,
                     Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getContingencyId().startsWith("3")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getContingencyId().startsWith("3"))
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(
                         ), 1)
         );
     }
@@ -225,12 +230,20 @@ class FindContingenciesTest {
         return Stream.of(
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.CONTAINS, "CO", ContingencyEntity.Fields.status)), PageRequest.of(0, 30,
                     Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getStatus().contains("CO")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4),
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getStatus().contains("CO"))
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4),
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.EQUALS, "ONE",
                     ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side)), PageRequest.of(0, 30,
                             Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
                 getResultContingenciesWithNestedFilter(lm -> lm.getLimitViolation().getSide() != null
-                        && lm.getLimitViolation().getSide().equals(ThreeSides.ONE)).stream().sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4),
+                        && lm.getLimitViolation().getSide().equals(ThreeSides.ONE)).stream()
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4),
+            Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.EQUALS, "TWO",
+                    ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.side)), PageRequest.of(0, 30,
+                    Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
+                getResultContingenciesWithNestedFilter(lm -> lm.getLimitViolation().getSide() != null
+                    && lm.getLimitViolation().getSide().equals(ThreeSides.TWO)).stream()
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4),
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.EQUALS, "l6_name",
                     ContingencyEntity.Fields.contingencyLimitViolations + SpecificationUtils.FIELD_SEPARATOR + AbstractLimitViolationEntity.Fields.limitName)), PageRequest.of(0, 30,
                             Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
@@ -248,7 +261,7 @@ class FindContingenciesTest {
                     new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.EQUALS, "CONVERGED", ContingencyEntity.Fields.status)
                 ),
                 PageRequest.of(0, 30, Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getContingencyId().contains("l") && c.getContingency().getContingencyId().contains("3")
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getContingencyId().contains("l") && c.getContingency().getContingencyId().contains("3")
                         && c.getContingency().getStatus().equals("CONVERGED")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(),
                 4), // list of parent filters
             Arguments.of(
@@ -281,10 +294,12 @@ class FindContingenciesTest {
     private static Stream<Arguments> provideEdgeCasesFilters() {
         return Stream.of(
             Arguments.of(List.of(), PageRequest.of(0, 30, Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                    RESULT_CONTINGENCIES.stream().sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4), // empty list of filter
+                    RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream()
+                        .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(), 4), // empty list of filter
             Arguments.of(List.of(new ResourceFilterDTO(ResourceFilterDTO.DataType.TEXT, ResourceFilterDTO.Type.CONTAINS, "co", ContingencyEntity.Fields.status)), PageRequest.of(0, 30,
                     Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId)),
-                RESULT_CONTINGENCIES.stream().filter(c -> c.getContingency().getStatus().contains("CO")).sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(),
+                RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().filter(c -> c.getContingency().getStatus().contains("CO"))
+                    .sorted(Comparator.comparing(FindContingenciesTest::getContingencyResultDTOId)).toList(),
                         4) // case insensitive search test
         );
     }

--- a/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/FindContingenciesTest.java
@@ -6,11 +6,23 @@
  */
 package org.gridsuite.securityanalysis.server;
 
+import com.powsybl.contingency.BranchContingency;
+import com.powsybl.contingency.Contingency;
+import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.violations.LimitViolation;
 import com.powsybl.contingency.violations.LimitViolationType;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.ThreeSides;
+import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.iidm.network.test.EurostagTutorialExample1Factory;
+import com.powsybl.loadflow.LoadFlowResult;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
+import com.powsybl.security.LimitViolationsResult;
+import com.powsybl.security.PostContingencyComputationStatus;
+import com.powsybl.security.SecurityAnalysisResult;
+import com.powsybl.security.results.ConnectivityResult;
+import com.powsybl.security.results.NetworkResult;
+import com.powsybl.security.results.PostContingencyResult;
 import org.gridsuite.computation.dto.ResourceFilterDTO;
 import org.gridsuite.computation.error.ComputationException;
 import org.gridsuite.computation.utils.SpecificationUtils;
@@ -18,6 +30,7 @@ import org.gridsuite.securityanalysis.server.dto.ContingencyResultDTO;
 import org.gridsuite.securityanalysis.server.dto.SecurityAnalysisStatus;
 import org.gridsuite.securityanalysis.server.dto.SubjectLimitViolationDTO;
 import org.gridsuite.securityanalysis.server.entities.AbstractLimitViolationEntity;
+import org.gridsuite.securityanalysis.server.entities.ContingencyElementEmbeddable;
 import org.gridsuite.securityanalysis.server.entities.ContingencyEntity;
 import org.gridsuite.securityanalysis.server.entities.SecurityAnalysisResultEntity;
 import org.gridsuite.securityanalysis.server.entities.SubjectLimitViolationEntity;
@@ -25,6 +38,7 @@ import org.gridsuite.securityanalysis.server.repositories.SecurityAnalysisResult
 import org.gridsuite.securityanalysis.server.service.SecurityAnalysisResultService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -36,6 +50,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
@@ -114,6 +129,56 @@ class FindContingenciesTest {
     void testSortAndFilterErrors(List<ResourceFilterDTO> filters, Pageable pageable, Exception expectedException) {
         Exception exception = assertThrows(expectedException.getClass(), () -> securityAnalysisResultService.findContingenciesPage(resultEntity.getId(), filters, pageable));
         assertEquals(expectedException.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void findFilteredContingencyResultsDoNotDuplicateLimitViolations() {
+        UUID resultUuid = UUID.randomUUID();
+        String contingencyId1 = "contingency-1";
+        String contingencyId2 = "contingency-2";
+        SecurityAnalysisResult securityAnalysisResult = new SecurityAnalysisResult(
+            new LimitViolationsResult(List.of()),
+            LoadFlowResult.ComponentResult.Status.CONVERGED,
+            List.of(
+                createPostContingencyResult(contingencyId1, "element-1", "element-2"),
+                createPostContingencyResult(contingencyId2, "element-3", "element-4")
+            )
+        );
+        securityAnalysisResultService.insert(null, resultUuid, securityAnalysisResult, SecurityAnalysisStatus.CONVERGED);
+
+        ResourceFilterDTO globalFilter = new ResourceFilterDTO(
+            ResourceFilterDTO.DataType.TEXT,
+            ResourceFilterDTO.Type.CONTAINS,
+            "element",
+            ContingencyEntity.Fields.contingencyElements + SpecificationUtils.FIELD_SEPARATOR + ContingencyElementEmbeddable.Fields.elementId
+        );
+
+        Page<ContingencyEntity> contingenciesPage = securityAnalysisResultService.findContingenciesPage(
+            resultUuid,
+            List.of(globalFilter),
+            PageRequest.of(0, 5, Sort.by(Sort.Direction.ASC, ContingencyEntity.Fields.contingencyId))
+        );
+
+        assertThat(contingenciesPage.getContent())
+            .hasSize(2)
+                .extracting(ContingencyEntity::getContingencyLimitViolations)
+                .allSatisfy(limitViolations ->
+                        assertThat(limitViolations).hasSize(1)
+                );
+    }
+
+    private static PostContingencyResult createPostContingencyResult(String contingencyId, String... elementIds) {
+        return new PostContingencyResult(
+            new Contingency(contingencyId, Arrays.stream(elementIds)
+                .map(elementId -> (ContingencyElement) new BranchContingency(elementId))
+                .toList()),
+            PostContingencyComputationStatus.CONVERGED,
+            new LimitViolationsResult(List.of(new LimitViolation(
+                    "subject", LimitViolationType.CURRENT, "limit", 60, 100, 1, 110, TwoSides.ONE))),
+            NetworkResult.empty(),
+            ConnectivityResult.empty(),
+            1.0
+        );
     }
 
     private static Stream<Arguments> providePageableAndSortOnly() {

--- a/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
+++ b/src/test/java/org/gridsuite/securityanalysis/server/SecurityAnalysisProviderMock.java
@@ -98,6 +98,7 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
 
     //MAX VALUE for acceptable duration here is important to check this value is actually set to null when exporting it
     static final LimitViolation LIMIT_VIOLATION_1 = new LimitViolation("l3", LimitViolationType.CURRENT, "l3_name", Integer.MAX_VALUE, 10, 1, 11, TwoSides.ONE);
+    static final LimitViolation LIMIT_VIOLATION_1_OTHER_SIDE = new LimitViolation("l3", LimitViolationType.CURRENT, "l3_name", Integer.MAX_VALUE, 10, 1, 11, TwoSides.TWO);
     static final LimitViolation LIMIT_VIOLATION_2 = new LimitViolation("vl1", null, LimitViolationType.HIGH_VOLTAGE, "permanent", 0, 400, 1, 410, null, new BusBreakerViolationLocation(List.of("NGEN",
             "NLOAD")));
     static final LimitViolation LIMIT_VIOLATION_3 = new LimitViolation("l6", LimitViolationType.CURRENT, "l6_name", 20 * 60, 10, 1, 11, TwoSides.ONE);
@@ -106,6 +107,7 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
             new BusBreakerViolationLocation(List.of("NLOAD")));
     static final LimitViolation LIMIT_VIOLATION_6 = new LimitViolation("l7", LimitViolationType.CURRENT, "l7_name", 20 * 60, 10.51242140448186, 1.00001290229799f, 11.024281313654868, TwoSides.ONE);
     static final List<LimitViolation> RESULT_LIMIT_VIOLATIONS = List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2);
+    static final List<LimitViolation> LIMIT_VIOLATIONS_ON_BOTH_SIDES = List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_1_OTHER_SIDE, LIMIT_VIOLATION_2);
     static final List<LimitViolation> FAILED_LIMIT_VIOLATIONS = List.of(LIMIT_VIOLATION_3, LIMIT_VIOLATION_4);
 
     public static final SecurityAnalysisResult RESULT = new SecurityAnalysisResult(new LimitViolationsResult(List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_3)),
@@ -125,6 +127,24 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
                                             new LimitViolationsResult(List.of()), NetworkResult.empty(), EMPTY_CUT_OFF, 1.0)))
                     .flatMap(Function.identity())
                     .toList());
+    public static final SecurityAnalysisResult RESULT_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES = new SecurityAnalysisResult(new LimitViolationsResult(List.of(
+        LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_3)),
+        LoadFlowResult.ComponentResult.Status.CONVERGED,
+        Stream.of(
+                CONTINGENCIES.stream().map(contingencyInfo ->
+                    new PostContingencyResult(contingencyInfo.getContingency(), PostContingencyComputationStatus.CONVERGED,
+                        new LimitViolationsResult(LIMIT_VIOLATIONS_ON_BOTH_SIDES), NetworkResult.empty(), CONNECTIVITY_RESULT, 1.0)),
+                FAILED_CONTINGENCIES.stream().map(contingency ->
+                    new PostContingencyResult(contingency, PostContingencyComputationStatus.FAILED,
+                        new LimitViolationsResult(FAILED_LIMIT_VIOLATIONS), NetworkResult.empty(), CONNECTIVITY_RESULT, 1.0)),
+                CONTINGENCIES_WITHOUT_LIMIT_VIOLATION.stream().map(contingency ->
+                    new PostContingencyResult(contingency, PostContingencyComputationStatus.CONVERGED,
+                        new LimitViolationsResult(List.of()), NetworkResult.empty(), EMPTY_CUT_OFF, 1.0)),
+                CONTINGENCIES_NOT_CONVERGED_WITHOUT_LIMIT_VIOLATION.stream().map(contingency ->
+                    new PostContingencyResult(contingency, PostContingencyComputationStatus.FAILED,
+                        new LimitViolationsResult(List.of()), NetworkResult.empty(), EMPTY_CUT_OFF, 1.0)))
+            .flatMap(Function.identity())
+            .toList());
     static final List<LimitViolation> RESULT_PRECONTINGENCY_LIMIT_VIOLATIONS = List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_5, LIMIT_VIOLATION_6);
     static final SecurityAnalysisResult PRECONTINGENCY_RESULT = new SecurityAnalysisResult(new LimitViolationsResult(List.of(LIMIT_VIOLATION_1, LIMIT_VIOLATION_2, LIMIT_VIOLATION_5,
             LIMIT_VIOLATION_6)), LoadFlowResult.ComponentResult.Status.CONVERGED,
@@ -154,9 +174,14 @@ public class SecurityAnalysisProviderMock implements SecurityAnalysisProvider {
         FAILED_CONTINGENCIES.stream().map(c -> toContingencyResultDTO(c, LoadFlowResult.ComponentResult.Status.FAILED.name(), FAILED_LIMIT_VIOLATIONS)),
         CONTINGENCIES_NOT_CONVERGED_WITHOUT_LIMIT_VIOLATION.stream().map(c -> toContingencyResultDTO(c, LoadFlowResult.ComponentResult.Status.FAILED.name(), List.of())))
             .flatMap(Function.identity()).toList();
+    static final List<ContingencyResultDTO> RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES = Stream.of(
+            CONTINGENCIES.stream().map(c -> toContingencyResultDTO(c.getContingency(), LoadFlowResult.ComponentResult.Status.CONVERGED.name(), LIMIT_VIOLATIONS_ON_BOTH_SIDES)),
+            FAILED_CONTINGENCIES.stream().map(c -> toContingencyResultDTO(c, LoadFlowResult.ComponentResult.Status.FAILED.name(), FAILED_LIMIT_VIOLATIONS)),
+            CONTINGENCIES_NOT_CONVERGED_WITHOUT_LIMIT_VIOLATION.stream().map(c -> toContingencyResultDTO(c, LoadFlowResult.ComponentResult.Status.FAILED.name(), List.of())))
+        .flatMap(Function.identity()).toList();
 
     static List<ContingencyResultDTO> getResultContingenciesWithNestedFilter(Function<SubjectLimitViolationDTO, Boolean> filterMethod) {
-        return RESULT_CONTINGENCIES.stream().map(r ->
+        return RESULT_CONTINGENCIES_WITH_LIMIT_VIOLATIONS_ON_BOTH_SIDES.stream().map(r ->
             new ContingencyResultDTO(
                 r.getContingency(),
                 r.getSubjectLimitViolations().stream()


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->
When filtering the security analysis n-k results using the global filter, the limit violations results may be duplicated in the case of multiple contingencies.


